### PR TITLE
Wire up Trivy + Cosign image security gates, add SonarCloud quality gate

### DIFF
--- a/.github/workflows/basket-ci.yml
+++ b/.github/workflows/basket-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/basket-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: basket
       testProjectPath: src/Services/Basket/FreshCart.Basket.Tests/FreshCart.Basket.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: basket
+      dockerfilePath: src/Services/Basket/FreshCart.Basket.Api/Dockerfile

--- a/.github/workflows/catalog-ci.yml
+++ b/.github/workflows/catalog-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/catalog-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: catalog
       testProjectPath: src/Services/Catalog/FreshCart.Catalog.Tests/FreshCart.Catalog.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: catalog
+      dockerfilePath: src/Services/Catalog/FreshCart.Catalog.Api/Dockerfile

--- a/.github/workflows/customersupport-ci.yml
+++ b/.github/workflows/customersupport-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/customersupport-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: customersupport
       testProjectPath: src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/FreshCart.CustomerSupport.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: customersupport
+      dockerfilePath: src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/Dockerfile

--- a/.github/workflows/delivery-ci.yml
+++ b/.github/workflows/delivery-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/delivery-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: delivery
       testProjectPath: src/Services/Delivery/FreshCart.Delivery.Tests/FreshCart.Delivery.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: delivery
+      dockerfilePath: src/Services/Delivery/FreshCart.Delivery.Api/Dockerfile

--- a/.github/workflows/gateway-ci.yml
+++ b/.github/workflows/gateway-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/gateway-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: gateway
       testProjectPath: src/ApiGateways/FreshCart.Gateway.Tests/FreshCart.Gateway.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: gateway
+      dockerfilePath: src/ApiGateways/FreshCart.Gateway.Yarp/Dockerfile

--- a/.github/workflows/identity-ci.yml
+++ b/.github/workflows/identity-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/identity-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: identity
       testProjectPath: src/Services/Identity/FreshCart.Identity.Tests/FreshCart.Identity.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: identity
+      dockerfilePath: src/Services/Identity/FreshCart.Identity.Api/Dockerfile

--- a/.github/workflows/inventory-ci.yml
+++ b/.github/workflows/inventory-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/inventory-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: inventory
       testProjectPath: src/Services/Inventory/FreshCart.Inventory.Tests/FreshCart.Inventory.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: inventory
+      dockerfilePath: src/Services/Inventory/FreshCart.Inventory.Api/Dockerfile

--- a/.github/workflows/notification-ci.yml
+++ b/.github/workflows/notification-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/notification-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: notification
       testProjectPath: src/Services/Notification/FreshCart.Notification.Tests/FreshCart.Notification.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: notification
+      dockerfilePath: src/Services/Notification/FreshCart.Notification.Api/Dockerfile

--- a/.github/workflows/ordering-ci.yml
+++ b/.github/workflows/ordering-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/ordering-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: ordering
       testProjectPath: src/Services/Ordering/FreshCart.Ordering.Tests/FreshCart.Ordering.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: ordering
+      dockerfilePath: src/Services/Ordering/FreshCart.Ordering.Api/Dockerfile

--- a/.github/workflows/payment-ci.yml
+++ b/.github/workflows/payment-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/payment-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: payment
       testProjectPath: src/Services/Payment/FreshCart.Payment.Tests/FreshCart.Payment.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: payment
+      dockerfilePath: src/Services/Payment/FreshCart.Payment.Api/Dockerfile

--- a/.github/workflows/pricing-ci.yml
+++ b/.github/workflows/pricing-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/pricing-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: pricing
       testProjectPath: src/Services/Pricing/FreshCart.Pricing.Tests/FreshCart.Pricing.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: pricing
+      dockerfilePath: src/Services/Pricing/FreshCart.Pricing.Grpc/Dockerfile

--- a/.github/workflows/reporting-ci.yml
+++ b/.github/workflows/reporting-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/reporting-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: reporting
       testProjectPath: src/Services/Reporting/FreshCart.Reporting.Tests/FreshCart.Reporting.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: reporting
+      dockerfilePath: src/Services/Reporting/FreshCart.Reporting.Api/Dockerfile

--- a/.github/workflows/reusable-docker-security.yml
+++ b/.github/workflows/reusable-docker-security.yml
@@ -1,0 +1,78 @@
+# ---------------------------------------------------------------------------
+# Reusable Docker security gate for a single service: build the image once,
+# fail the job on any HIGH/CRITICAL fixable CVE (Trivy), and — on master only —
+# push to GHCR and keylessly sign the pushed digest (Cosign/Sigstore, no
+# stored signing key). Invoked by every per-service workflow via `workflow_call`.
+# ---------------------------------------------------------------------------
+name: reusable-docker-security
+
+on:
+  workflow_call:
+    inputs:
+      serviceName:
+        description: 'Short service name, used for the image tag and log labels.'
+        required: true
+        type: string
+      dockerfilePath:
+        description: 'Relative path to the service Dockerfile.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  docker-security:
+    name: Docker build · Trivy scan · sign (${{ inputs.serviceName }})
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/freshcart-${{ inputs.serviceName }}:${{ github.sha }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (local)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ inputs.dockerfilePath }}
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}
+
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/master'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        if: github.ref == 'refs/heads/master'
+        run: docker push "${{ env.IMAGE }}"
+
+      - name: Install Cosign
+        if: github.ref == 'refs/heads/master'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless, Sigstore OIDC)
+        if: github.ref == 'refs/heads/master'
+        run: |
+          digest=$(docker inspect --format='{{index .RepoDigests 0}}' "${{ env.IMAGE }}")
+          cosign sign --yes "$digest"

--- a/.github/workflows/reusable-docker-security.yml
+++ b/.github/workflows/reusable-docker-security.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Cosign
         if: github.ref == 'refs/heads/master'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image (keyless, Sigstore OIDC)
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/reusable-docker-security.yml
+++ b/.github/workflows/reusable-docker-security.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image (local)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ inputs.dockerfilePath }}
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ env.IMAGE }}
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}
           format: table
@@ -57,7 +57,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.ref == 'refs/heads/master'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Cosign
         if: github.ref == 'refs/heads/master'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign image (keyless, Sigstore OIDC)
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/reviews-ci.yml
+++ b/.github/workflows/reviews-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'src/BuildingBlocks/**'
       - '.github/workflows/reviews-ci.yml'
       - '.github/workflows/reusable-build-test.yml'
+      - '.github/workflows/reusable-docker-security.yml'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
@@ -33,3 +34,14 @@ jobs:
     with:
       serviceName: reviews
       testProjectPath: src/Services/Reviews/FreshCart.Reviews.Tests/FreshCart.Reviews.Tests.csproj
+
+  docker-security:
+    name: Docker security
+    uses: ./.github/workflows/reusable-docker-security.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      serviceName: reviews
+      dockerfilePath: src/Services/Reviews/FreshCart.Reviews.Api/Dockerfile

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------
+# SonarCloud quality gate for the whole solution (one project, not one per
+# service — a monorepo analysis needs the full build graph to do meaningful
+# cross-project analysis). Requires a SONAR_TOKEN repo secret; until it's set,
+# the analysis steps skip with a warning instead of failing every run.
+# ---------------------------------------------------------------------------
+name: sonarcloud
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud quality gate
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET SDK (from global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Set up JDK 17 (required by the Sonar scanner)
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache SonarCloud packages
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install SonarCloud scanner
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Begin analysis
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: >
+          dotnet-sonarscanner begin
+          /k:"amasen02_freshcart-backend"
+          /o:"amasen02"
+          /d:sonar.token="${{ env.SONAR_TOKEN }}"
+          /d:sonar.host.url="https://sonarcloud.io"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --configuration Release --no-restore
+
+      - name: End analysis
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: dotnet-sonarscanner end /d:sonar.token="${{ env.SONAR_TOKEN }}"
+
+      - name: Gate not yet configured
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: echo "::warning::SONAR_TOKEN is not set — create the amasen02_freshcart-backend project on sonarcloud.io and add SONAR_TOKEN as a repo secret to activate this gate."

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -62,11 +62,17 @@ jobs:
           /d:sonar.token="${{ env.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"
 
+      - name: Generate a whole-repo solution file
+        run: |
+          dotnet new sln -n FreshCart
+          find . -name "*.csproj" -not -path "*/bin/*" -not -path "*/obj/*" -print0 \
+            | xargs -0 dotnet sln FreshCart.sln add
+
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore FreshCart.sln
 
       - name: Build (Release)
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build FreshCart.sln --configuration Release --no-restore
 
       - name: End analysis
         if: ${{ env.SONAR_TOKEN != '' }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -66,13 +66,13 @@ jobs:
         run: |
           dotnet new sln -n FreshCart
           find . -name "*.csproj" -not -path "*/bin/*" -not -path "*/obj/*" -print0 \
-            | xargs -0 dotnet sln FreshCart.sln add
+            | xargs -0 dotnet sln FreshCart.slnx add
 
       - name: Restore
-        run: dotnet restore FreshCart.sln
+        run: dotnet restore FreshCart.slnx
 
       - name: Build (Release)
-        run: dotnet build FreshCart.sln --configuration Release --no-restore
+        run: dotnet build FreshCart.slnx --configuration Release --no-restore
 
       - name: End analysis
         if: ${{ env.SONAR_TOKEN != '' }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,9 @@
   <ItemGroup Label="ASP.NET Core + Hosting">
     <!-- 10.0.9 servicing line clears CVE-2026-40372 (DataProtection) and CVE-2026-33116/26171 (Cryptography.Xml). -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Transitive pin: Microsoft.AspNetCore.OpenApi 10.0.9 floors Microsoft.OpenApi at 2.0.0,
+         which carries GHSA-v5pm-xwqc-g5wc (stack-overflow DoS on circular schema refs). Fixed in 2.7.5+. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.9" />

--- a/README.md
+++ b/README.md
@@ -313,7 +313,12 @@ freshcart-backend/
 ## Continuous integration
 
 Every service builds and runs its full test suite (unit + Testcontainers integration tests) on
-each push to `master`, and CodeQL scans the C# code for security issues:
+each push to `master`, and CodeQL scans the C# code for security issues. Each service's Docker
+image is also built, scanned with **Trivy** (blocks the merge on any fixable HIGH/CRITICAL CVE),
+and — on `master` — pushed to GHCR and keylessly signed with **Cosign** (Sigstore OIDC, no stored
+signing key). A **SonarCloud** whole-solution quality gate (`sonarcloud.yml`) is wired up and
+ready; it activates once a `SONAR_TOKEN` repo secret is added (until then it skips cleanly with a
+warning instead of failing every build):
 
 [![identity](https://github.com/amasen02/freshcart-backend/actions/workflows/identity-ci.yml/badge.svg)](https://github.com/amasen02/freshcart-backend/actions/workflows/identity-ci.yml)
 [![catalog](https://github.com/amasen02/freshcart-backend/actions/workflows/catalog-ci.yml/badge.svg)](https://github.com/amasen02/freshcart-backend/actions/workflows/catalog-ci.yml)


### PR DESCRIPTION
## Summary
- Adds a `reusable-docker-security.yml` workflow, invoked by every per-service CI: builds the service's Docker image, fails the job on any fixable HIGH/CRITICAL CVE (Trivy), and on `master` pushes the image to GHCR and signs it keylessly with Cosign (Sigstore OIDC — no stored signing key).
- Adds `sonarcloud.yml`: whole-solution SonarCloud analysis, gated on a `SONAR_TOKEN` repo secret. Until that secret exists it skips cleanly with a `::warning::` instead of failing every run.
- Updates the README's Continuous Integration section to describe what's actually live vs. pending.

## Before this is fully active
1. Create the `amasen02_freshcart-backend` project on sonarcloud.io (free for public repos) under the `amasen02` org.
2. Add `SONAR_TOKEN` as a repo secret (Settings → Secrets and variables → Actions).
3. Merge — Trivy/Cosign need no further setup (GHCR push uses the default `GITHUB_TOKEN`, Cosign uses keyless OIDC).

## Test plan
- [ ] Confirm each per-service workflow run shows a new `docker-security` job alongside `build-test`
- [ ] Confirm Trivy fails the job on a deliberately vulnerable base image (spot check one service)
- [ ] Confirm an image lands in GHCR and `cosign verify` succeeds against it after merging to master
- [ ] Add `SONAR_TOKEN` and confirm `sonarcloud.yml` actually runs analysis instead of skipping