### PR TITLE
ci: add pull request labeling workflow for community contributions (#8)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,87 @@
+# FreshCart PR Labeler Configuration
+# Automatically applies area and component labels based on modified file paths
+
+area/gateway:
+  - changed-files:
+      - any-glob-to-any-file: 'src/ApiGateways/**/*'
+
+area/basket:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Basket/**/*'
+
+area/catalog:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Catalog/**/*'
+
+area/customersupport:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/CustomerSupport/**/*'
+
+area/delivery:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Delivery/**/*'
+
+area/identity:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Identity/**/*'
+
+area/inventory:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Inventory/**/*'
+
+area/notification:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Notification/**/*'
+
+area/ordering:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Ordering/**/*'
+
+area/payment:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Payment/**/*'
+
+area/pricing:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Pricing/**/*'
+
+area/reporting:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Reporting/**/*'
+
+area/reviews:
+  - changed-files:
+      - any-glob-to-any-file: 'src/Services/Reviews/**/*'
+
+area/apphost:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/FreshCart.AppHost/**/*'
+          - 'src/FreshCart.ServiceDefaults/**/*'
+
+area/deploy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'deploy/**/*'
+          - 'gitops/**/*'
+
+area/infra:
+  - changed-files:
+      - any-glob-to-any-file: 'infra/**/*'
+
+area/tests:
+  - changed-files:
+      - any-glob-to-any-file: 'tests/**/*'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**/*'
+          - '**/*.md'
+          - '**/*.html'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
+          - 'azure-pipelines/**/*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
### Summary
Adds automatic pull request categorization using GitHub's official \ctions/labeler@v5\ action.

### Changes
- \.github/labeler.yml\: Configures component paths (\rea/gateway\, \rea/basket\, \rea/catalog\, \rea/pricing\, \rea/ordering\, \rea/deploy\, \documentation\, etc.).
- \.github/workflows/labeler.yml\: Listens to \pull_request_target\ events with least-privilege \pull-requests: write\ permissions.

Closes #8.