### PR TITLE
Run customer E2E tests against an ephemeral local stack

### DIFF
--- a/.github/scripts/freshcart-e2e-stack.sh
+++ b/.github/scripts/freshcart-e2e-stack.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_commands=(curl docker dotnet npm setsid)
+
+preflight() {
+  [[ "${CI:-}" == true ]] || { echo "This helper is restricted to an isolated CI Docker host" >&2; return 1; }
+  local missing=()
+  for command_name in "${required_commands[@]}"; do
+    command -v "$command_name" >/dev/null 2>&1 || missing+=("$command_name")
+  done
+  if ((${#missing[@]})); then
+    echo "Missing required commands: ${missing[*]}" >&2
+    return 1
+  fi
+  docker info >/dev/null
+}
+
+snapshot_docker() {
+  local state_dir=$1
+  mkdir -p "$state_dir"
+  docker ps -aq | sort -u > "$state_dir/containers.before"
+  docker volume ls -q | sort -u > "$state_dir/volumes.before"
+  docker network ls -q | sort -u > "$state_dir/networks.before"
+}
+
+start_stack() {
+  local state_dir=$1 backend_dir=$2 frontend_dir=$3
+  mkdir -p "$state_dir"
+  snapshot_docker "$state_dir"
+  (cd "$backend_dir" && exec setsid env FreshCart__Ephemeral=true dotnet run --project src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj --launch-profile http) > "$state_dir/apphost.log" 2>&1 &
+  echo $! > "$state_dir/apphost.pid"
+  (cd "$frontend_dir" && exec setsid npm start -- --host 127.0.0.1 --port 4200) > "$state_dir/storefront.log" 2>&1 &
+  echo $! > "$state_dir/storefront.pid"
+}
+
+wait_for_url() {
+  local name=$1 url=$2 timeout_seconds=$3 state_dir=$4 curl_insecure=${5:-false}
+  local deadline=$((SECONDS + timeout_seconds)) curl_args=(--fail --silent --show-error --max-time 5)
+  [[ "$curl_insecure" == true ]] && curl_args+=(--insecure)
+  while ((SECONDS < deadline)); do
+    for pid_file in "$state_dir/apphost.pid" "$state_dir/storefront.pid"; do
+      if [[ -f "$pid_file" ]] && ! kill -0 "$(<"$pid_file")" 2>/dev/null; then
+        echo "A stack process exited while waiting for $name" >&2
+        tail -n 80 "$state_dir/apphost.log" "$state_dir/storefront.log" 2>/dev/null || true
+        return 1
+      fi
+    done
+    if curl "${curl_args[@]}" "$url" >/dev/null 2>&1; then echo "ready: $name ($url)"; return 0; fi
+    sleep 2
+  done
+  echo "Timed out after ${timeout_seconds}s waiting for $name ($url)" >&2
+  tail -n 80 "$state_dir/apphost.log" "$state_dir/storefront.log" 2>/dev/null || true
+  return 1
+}
+
+wait_for_stack() {
+  local state_dir=$1 timeout_seconds=${2:-600}
+  local deadline=$((SECONDS + timeout_seconds))
+  wait_one() {
+    local remaining=$((deadline - SECONDS))
+    ((remaining > 0)) || { echo "Global stack readiness timeout expired" >&2; return 1; }
+    wait_for_url "$1" "$2" "$remaining" "$state_dir" "${3:-false}"
+  }
+  wait_one identity http://localhost:5101/ready
+  wait_one catalog http://localhost:5102/ready
+  wait_one basket http://localhost:5104/ready
+  wait_one ordering http://localhost:5105/ready
+  wait_one payment http://localhost:5107/ready
+  wait_one notification http://localhost:5109/ready
+  wait_one reporting http://localhost:5110/ready
+  wait_one gateway https://localhost:7100/ready true
+  wait_one storefront http://localhost:4200
+}
+
+new_docker_ids() {
+  local kind=$1 before_file=$2
+  case "$kind" in containers) docker ps -aq ;; volumes) docker volume ls -q ;; networks) docker network ls -q ;; esac | sort -u | comm -13 "$before_file" -
+}
+
+cleanup() {
+  local state_dir=$1 pid
+  [[ "${CI:-}" == true ]] || { echo "Cleanup is restricted to an isolated CI Docker host" >&2; return 1; }
+  for snapshot in containers.before volumes.before networks.before; do
+    [[ -f "$state_dir/$snapshot" ]] || { echo "Ownership snapshot is incomplete; refusing Docker cleanup" >&2; return 1; }
+  done
+  for pid_file in "$state_dir/storefront.pid" "$state_dir/apphost.pid"; do
+    if [[ -f "$pid_file" ]]; then
+      pid=$(<"$pid_file")
+      kill -- "-$pid" 2>/dev/null || true
+      for _ in {1..20}; do kill -0 -- "-$pid" 2>/dev/null || break; sleep 0.5; done
+      if kill -0 -- "-$pid" 2>/dev/null; then
+        kill -KILL -- "-$pid" 2>/dev/null || true
+        for _ in {1..10}; do kill -0 -- "-$pid" 2>/dev/null || break; sleep 0.2; done
+      fi
+      kill -0 -- "-$pid" 2>/dev/null && { echo "Process group $pid survived cleanup" >&2; return 1; }
+    fi
+  done
+  mapfile -t containers < <(new_docker_ids containers "$state_dir/containers.before")
+  ((${#containers[@]} == 0)) || docker rm -f "${containers[@]}"
+  mapfile -t volumes < <(new_docker_ids volumes "$state_dir/volumes.before")
+  ((${#volumes[@]} == 0)) || docker volume rm "${volumes[@]}"
+  mapfile -t networks < <(new_docker_ids networks "$state_dir/networks.before")
+  ((${#networks[@]} == 0)) || docker network rm "${networks[@]}"
+  [[ -z "$(new_docker_ids containers "$state_dir/containers.before")$(new_docker_ids volumes "$state_dir/volumes.before")$(new_docker_ids networks "$state_dir/networks.before")" ]] || { echo "FreshCart-owned Docker resources remain after cleanup" >&2; return 1; }
+}
+
+if [[ "${FRESHCART_STACK_LIB_ONLY:-}" != 1 ]]; then
+  command_name=${1:-}; shift || true
+  case "$command_name" in preflight) preflight "$@" ;; start) start_stack "$@" ;; wait) wait_for_stack "$@" ;; cleanup) cleanup "$@" ;; *) echo "Usage: $0 {preflight|start|wait|cleanup}" >&2; exit 2 ;; esac
+fi

--- a/.github/scripts/test-freshcart-e2e-stack.sh
+++ b/.github/scripts/test-freshcart-e2e-stack.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+export FRESHCART_STACK_LIB_ONLY=1
+source "$script_dir/freshcart-e2e-stack.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+export CI=true
+
+original_path=$PATH; PATH=$tmp_dir; unset CI
+if preflight >/dev/null 2>&1; then echo "preflight passed without prerequisites" >&2; exit 1; fi
+PATH=$original_path; export CI=true
+
+(exit 7) & dead_pid=$!; wait "$dead_pid" 2>/dev/null || true
+echo "$dead_pid" > "$tmp_dir/apphost.pid"; : > "$tmp_dir/apphost.log"; : > "$tmp_dir/storefront.log"
+if wait_for_url dead-service http://127.0.0.1:1 1 "$tmp_dir" >/dev/null 2>&1; then echo "dead process was ignored" >&2; exit 1; fi
+rm "$tmp_dir/apphost.pid"
+
+started=$SECONDS
+if wait_for_url timeout-service http://127.0.0.1:1 1 "$tmp_dir" >/dev/null 2>&1; then echo "unreachable endpoint passed" >&2; exit 1; fi
+((SECONDS - started >= 1)) || { echo "timeout was not honored" >&2; exit 1; }
+
+# Cleanup may remove only resources created after the ownership snapshot.
+state="$tmp_dir/cleanup"; mkdir -p "$state"
+printf 'existing-container\n' > "$state/containers.before"
+printf 'existing-volume\n' > "$state/volumes.before"
+printf 'existing-network\n' > "$state/networks.before"
+printf 'existing-container\nnew-container\n' > "$tmp_dir/containers.current"
+printf 'existing-volume\nnew-volume\n' > "$tmp_dir/volumes.current"
+printf 'existing-network\nnew-network\n' > "$tmp_dir/networks.current"
+: > "$tmp_dir/removals"
+setsid bash -c 'sleep 30 & wait' & owned_group=$!
+echo "$owned_group" > "$state/storefront.pid"
+docker() {
+  if [[ "$1 $2" == 'ps -aq' ]]; then cat "$tmp_dir/containers.current"
+  elif [[ "$1 $2 $3" == 'volume ls -q' ]]; then cat "$tmp_dir/volumes.current"
+  elif [[ "$1 $2 $3" == 'network ls -q' ]]; then cat "$tmp_dir/networks.current"
+  elif [[ "$1 $2" == 'rm -f' ]]; then printf 'container:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/containers.before" "$tmp_dir/containers.current"
+  elif [[ "$1 $2" == 'volume rm' ]]; then printf 'volume:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/volumes.before" "$tmp_dir/volumes.current"
+  elif [[ "$1 $2" == 'network rm' ]]; then printf 'network:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/networks.before" "$tmp_dir/networks.current"
+  else return 1
+  fi
+}
+cleanup "$state"
+wait "$owned_group" 2>/dev/null || true
+if kill -0 -- "-$owned_group" 2>/dev/null; then echo "cleanup left its process group running" >&2; exit 1; fi
+grep -Fx 'container:new-container' "$tmp_dir/removals"
+grep -Fx 'volume:new-volume' "$tmp_dir/removals"
+grep -Fx 'network:new-network' "$tmp_dir/removals"
+if grep -F 'existing-' "$tmp_dir/removals"; then echo "cleanup removed a pre-existing resource" >&2; exit 1; fi
+
+echo "freshcart-e2e-stack: 5 checks passed"

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,27 +1,18 @@
-# ---------------------------------------------------------------------------
-# Playwright end-to-end — runs the customer happy-path against the local
-# Aspire stack on PR, against staging on a nightly cron.
-# ---------------------------------------------------------------------------
 name: e2e-playwright
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
     paths:
       - 'src/Services/**'
       - 'src/ApiGateways/**'
+      - 'src/AspireAppHost/**'
       - 'tests/e2e/**'
+      - '.github/scripts/**'
       - '.github/workflows/e2e-playwright.yml'
   schedule:
-    - cron: '0 3 * * *'         # nightly 03:00 UTC against staging
+    - cron: '0 3 * * *'
   workflow_dispatch:
-    inputs:
-      target:
-        description: 'Environment to target'
-        required: true
-        default: 'local'
-        type: choice
-        options: [local, dev, staging]
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -30,53 +21,121 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FRONTEND_SHA: acab0f75cf2622566d1edf340ef626d739604958
+  STACK_STATE: ${{ github.workspace }}/.freshcart-e2e
+
 jobs:
   e2e:
     name: Playwright (${{ matrix.project }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         project: [chromium, firefox, webkit]
 
     steps:
-      - name: Checkout
+      - name: Checkout backend
         uses: actions/checkout@v4
+
+      - name: Checkout compatible customer storefront
+        uses: actions/checkout@v4
+        with:
+          repository: amasen02/freshcart-web
+          ref: ${{ env.FRONTEND_SHA }}
+          path: freshcart-web
+
+      - name: Use .NET SDK from global.json
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
 
       - name: Use Node 22
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: tests/e2e/package-lock.json
+          cache: npm
+          cache-dependency-path: |
+            freshcart-web/package-lock.json
+            tests/e2e/package-lock.json
 
-      - name: Install Playwright + dependencies
-        working-directory: tests/e2e
+      - name: Verify runner prerequisites
+        run: bash .github/scripts/freshcart-e2e-stack.sh preflight
+
+      - name: Install storefront and Playwright
         run: |
-          npm ci
-          npx playwright install --with-deps ${{ matrix.project }}
+          npm ci --prefix freshcart-web
+          npm ci --prefix tests/e2e
+          npx --prefix tests/e2e playwright install --with-deps ${{ matrix.project }}
+          dotnet dev-certs https
 
-      - name: Resolve target URL
-        id: target
+      - name: Record runtime identity
+        shell: bash
         run: |
-          if [ "${{ github.event.inputs.target }}" = "staging" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "url=https://www.staging.freshcart.local" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.inputs.target }}" = "dev" ]; then
-            echo "url=https://www.dev.freshcart.local" >> "$GITHUB_OUTPUT"
-          else
-            echo "url=http://localhost:4200" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo '### FreshCart E2E runtime identity'
+            echo '- Backend: `${{ github.sha }}`'
+            echo '- Frontend: `${{ env.FRONTEND_SHA }}`'
+            printf -- '- .NET SDK: `%s`\n' "$(dotnet --version)"
+            printf -- '- Node: `%s`\n' "$(node --version)"
+            printf -- '- npm: `%s`\n' "$(npm --version)"
+            printf -- '- Backend dependency pins: `%s`\n' "$(sha256sum Directory.Packages.props global.json | sha256sum | cut -d' ' -f1)"
+            printf -- '- Frontend lock: `%s`\n' "$(sha256sum freshcart-web/package-lock.json | cut -d' ' -f1)"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Run tests
+      - name: Start ephemeral local stack
+        run: bash .github/scripts/freshcart-e2e-stack.sh start "$STACK_STATE" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/freshcart-web"
+
+      - name: Wait for journey dependencies
+        run: bash .github/scripts/freshcart-e2e-stack.sh wait "$STACK_STATE" 600
+
+      - name: Report admin surface availability
+        run: echo 'Admin E2E unavailable — this repository set has no admin SPA. The reporting-dashboard spec remains in source and is excluded from this customer-storefront gate.' | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify customer test discovery
         working-directory: tests/e2e
         env:
-          PLAYWRIGHT_BASE_URL: ${{ steps.target.outputs.url }}
-        run: npx playwright test --project=${{ matrix.project }}
+          PLAYWRIGHT_BASE_URL: http://localhost:4200
+        run: |
+          mkdir -p test-results
+          npx playwright test specs/auth.spec.ts specs/customer-journey.spec.ts --project=${{ matrix.project }} --list | tee test-results/discovery.txt
+          grep -F 'Total: 2 tests in 2 files' test-results/discovery.txt
 
-      - name: Upload Playwright report
+      - name: Run customer journey gate
+        working-directory: tests/e2e
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:4200
+        run: npx playwright test specs/auth.spec.ts specs/customer-journey.spec.ts --project=${{ matrix.project }}
+
+      - name: Verify executed test count
+        working-directory: tests/e2e
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const xml = fs.readFileSync('test-results/junit.xml', 'utf8');
+          const suites = xml.match(/<testsuites\b[^>]*>/)?.[0] ?? '';
+          const value = name => Number(suites.match(new RegExp(`${name}="(\\d+)"`))?.[1] ?? -1);
+          const actual = { tests: value('tests'), failures: value('failures'), skipped: value('skipped') };
+          if (actual.tests !== 2 || actual.failures !== 0 || actual.skipped !== 0) {
+            throw new Error(`Expected 2 passing and 0 skipped customer tests; received ${JSON.stringify(actual)}`);
+          }
+          console.log('Verified 2 passing customer tests with 0 skipped.');
+          NODE
+
+      - name: Upload E2E evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.project }}
-          path: tests/e2e/playwright-report
+          name: e2e-evidence-${{ matrix.project }}
+          path: |
+            tests/e2e/playwright-report
+            tests/e2e/test-results
+            ${{ env.STACK_STATE }}/*.log
           retention-days: 14
+          if-no-files-found: warn
+
+      - name: Clean up owned stack resources
+        if: always()
+        run: bash .github/scripts/freshcart-e2e-stack.sh cleanup "$STACK_STATE"

--- a/README.md
+++ b/README.md
@@ -37,15 +37,12 @@ to run in any other environment.
 # 0. Clone
 git clone https://github.com/amasen02/freshcart-backend.git && cd freshcart-backend
 
-# 1. Backing services (SQL Server, Postgres, MySQL, MongoDB, Redis, RabbitMQ, Seq, Grafana, Prometheus)
-docker compose -f deploy/docker/docker-compose.yaml up -d
+# 1. Whole .NET stack via Aspire — boots its backing stores, every microservice and the gateway
+dotnet run --project src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj --launch-profile http
 
-# 2. Whole .NET stack via Aspire — boots every microservice + the gateway + seeds demo accounts
-dotnet run --project src/AspireAppHost/FreshCart.AppHost
-
-# 3. Customer storefront (separate repo) — ng serve proxies /api and /hubs to the gateway on 7100
+# 2. Customer storefront (separate repo) — ng serve proxies /api and /hubs to the gateway on 7100
 git clone https://github.com/amasen02/freshcart-web.git
-cd freshcart-web && npm install && npm start
+cd freshcart-web && npm ci && npm start
 ```
 
 ### Open in the browser
@@ -245,7 +242,7 @@ Every item traces to an audit finding; the fixes and their verification are reco
 
 ## Infrastructure &amp; deployment
 
-- **Local.** Docker Compose + .NET Aspire AppHost.
+- **Local.** .NET Aspire AppHost (recommended), or Docker Compose for backing infrastructure when running services manually.
 - **Azure.** Bicep modules under [`infra/`](infra/) provision AKS, ACR, Azure SQL,
   Postgres Flexible Server, MySQL Flexible Server, Cosmos DB, Cache for Redis, Service Bus,
   Key Vault, App Configuration, Log Analytics, App Insights, Front Door + WAF, Storage,
@@ -344,7 +341,7 @@ warning instead of failing every build):
 Open the **[`index.html`](index.html)** landing page for the animated architecture guide. The
 deeper references are:
 
-- [`docs/quickstart.md`](docs/quickstart.md) &mdash; Step-by-step local setup with Docker Compose & Aspire.
+- [`docs/quickstart.md`](docs/quickstart.md) &mdash; Step-by-step local setup with Aspire or Docker Compose.
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) &mdash; C4 narrative + cross-cutting map.
 - [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) &mdash; naming, async, LINQ discipline.
 - [`docs/adr/`](docs/adr/) &mdash; architecture decision records.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,13 +1,13 @@
 # Local Development Quickstart Guide
 
-This guide walks you through bootstrapping the **FreshCart** microservices backend on your local development machine using Docker Compose and the .NET CLI.
+This guide walks you through bootstrapping the **FreshCart** microservices backend with .NET Aspire. A Docker Compose alternative is included for developers who want to run the services manually.
 
 ---
 
 ## 1. Prerequisites
 
 Ensure you have the following installed on your workstation:
-- **.NET SDK** (9.0 or 10.0-preview) &mdash; [Download .NET](https://dotnet.microsoft.com/download)
+- **.NET SDK 10.0.100** (the version selected by `global.json`) &mdash; [Download .NET](https://dotnet.microsoft.com/download)
 - **Docker Desktop** (or Docker Engine with Compose v2) &mdash; [Get Docker](https://www.docker.com/products/docker-desktop)
 - **Git**
 
@@ -28,40 +28,30 @@ cd freshcart-backend
 
 ---
 
-## 3. Launch Backing Services (Infrastructure Stack)
+## 3. Run the Complete Stack with Aspire (Recommended)
 
-FreshCart relies on PostgreSQL, Redis, RabbitMQ, and OpenTelemetry collector for event-driven messaging, caching, and observability. Launch them via the provided Docker Compose stack:
+The AppHost creates the backing stores and broker, starts all backend services, and supplies their service-discovery and connection-string configuration. Do not start the Compose stack as well, because that duplicates the same infrastructure and can cause port conflicts.
+
+```bash
+dotnet run --project src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj --launch-profile http
+```
+
+The terminal prints the Aspire Dashboard URL. Open it to inspect service health, logs, metrics, and traces.
+
+## 4. Compose Alternative for Manual Service Runs
+
+Use Compose only when you intend to run and configure the .NET services yourself:
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yaml up -d
-```
-
-### Checking Container Health
-Verify that all supporting databases and brokers are healthy:
-```bash
 docker compose -f deploy/docker/docker-compose.yaml ps
 ```
 
-Default ports mapped locally:
-| Service | Technology | Port | Credentials |
-| :--- | :--- | :--- | :--- |
-| **Identity & Catalog DB** | PostgreSQL | `5432` | `postgres` / `postgres` |
-| **Distributed Cache** | Redis | `6379` | None (local dev) |
-| **Event Bus** | RabbitMQ | `5672` (AMQP), `15672` (UI) | `guest` / `guest` |
-| **Metrics** | Prometheus | `9090` | N/A |
-| **Dashboards** | Grafana | `3000` | `admin` / `admin` |
-
----
-
-## 4. Run via .NET Aspire AppHost (Recommended)
-
-FreshCart is orchestrated using **.NET Aspire**. The `FreshCart.AppHost` automatically configures service discovery, connection strings, and resilience pipelines:
+Stop that alternative with:
 
 ```bash
-dotnet run --project src/FreshCart.AppHost/FreshCart.AppHost.csproj
+docker compose -f deploy/docker/docker-compose.yaml down -v
 ```
-
-Once started, the terminal will output the **Aspire Dashboard URL** (typically `https://localhost:17000`). Open it in your browser to inspect live metrics, structured logs, and distributed traces across all microservices.
 
 ---
 
@@ -78,9 +68,6 @@ dotnet test --logger "console;verbosity=normal"
 
 ---
 
-## 6. Stopping the Environment
+## 6. Stopping the Aspire Environment
 
-To tear down the Docker background containers:
-```bash
-docker compose -f deploy/docker/docker-compose.yaml down -v
-```
+Stop the AppHost process with `Ctrl+C`. Aspire owns the containers it started; the normal developer configuration keeps their data volumes for the next run.

--- a/src/AspireAppHost/FreshCart.AppHost/Program.cs
+++ b/src/AspireAppHost/FreshCart.AppHost/Program.cs
@@ -9,6 +9,10 @@
 // ---------------------------------------------------------------------------
 
 var distributedApplicationBuilder = DistributedApplication.CreateBuilder(args);
+var usePersistentBackingResources = !string.Equals(
+    distributedApplicationBuilder.Configuration["FreshCart:Ephemeral"],
+    "true",
+    StringComparison.OrdinalIgnoreCase);
 
 // Stable developer credentials for the persistent backing-service containers. Aspire mints a random
 // password per run by default, but WithDataVolume() + ContainerLifetime.Persistent reuse the container
@@ -27,9 +31,11 @@ var messageBrokerPassword = distributedApplicationBuilder.AddParameter("rabbitmq
 // --- Relational stores ------------------------------------------------------
 
 var sqlServer = distributedApplicationBuilder
-    .AddSqlServer("sqlserver", password: sqlServerPassword)
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    .AddSqlServer("sqlserver", password: sqlServerPassword);
+if (usePersistentBackingResources)
+{
+    sqlServer.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 // Identity (EF MigrateAsync) and Ordering (EF EnsureCreatedAsync) create their own database on startup,
 // so they are left to self-provision. The two raw-Dapper databases below have no EF creator and their
@@ -45,9 +51,11 @@ var paymentReadDatabase = sqlServer.AddDatabase("paymentreaddb")
     .WithCreationScript("IF DB_ID(N'paymentreaddb') IS NULL CREATE DATABASE [paymentreaddb];");
 
 var postgres = distributedApplicationBuilder
-    .AddPostgres("postgres", password: postgresPassword)
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    .AddPostgres("postgres", password: postgresPassword);
+if (usePersistentBackingResources)
+{
+    postgres.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 // Aspire's AddDatabase only registers a connection string; it does not CREATE DATABASE, and a Postgres
 // creation script would run against the not-yet-existing target database. Catalog and Basket therefore
@@ -56,9 +64,11 @@ var catalogDatabase = postgres.AddDatabase("catalogdb");
 var basketDatabase = postgres.AddDatabase("basketdb");
 
 var mysql = distributedApplicationBuilder
-    .AddMySql("mysql", password: mySqlPassword)
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    .AddMySql("mysql", password: mySqlPassword);
+if (usePersistentBackingResources)
+{
+    mysql.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 // Aspire's AddDatabase registers the connection string but does not create the MySQL database; the
 // Reporting warehouse initializer connects straight to reportingdb, so it must exist first.
@@ -90,9 +100,11 @@ var mongo = distributedApplicationBuilder
         context.Args.Add("-c");
         context.Args.Add(MongoReplicaSetInitScript);
         return Task.CompletedTask;
-    })
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    });
+if (usePersistentBackingResources)
+{
+    mongo.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 var deliveryDatabase = mongo.AddDatabase("deliverydb");
 var paymentEventStore = mongo.AddDatabase("paymentevents");
@@ -103,15 +115,19 @@ var notificationsDatabase = mongo.AddDatabase("notificationsdb");
 // --- Cache + broker ---------------------------------------------------------
 
 var distributedCache = distributedApplicationBuilder
-    .AddRedis("cache")
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    .AddRedis("cache");
+if (usePersistentBackingResources)
+{
+    distributedCache.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 var rabbitMq = distributedApplicationBuilder
     .AddRabbitMQ("rabbitmq", userName: messageBrokerUserName, password: messageBrokerPassword)
-    .WithManagementPlugin()
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+    .WithManagementPlugin();
+if (usePersistentBackingResources)
+{
+    rabbitMq.WithDataVolume().WithLifetime(ContainerLifetime.Persistent);
+}
 
 // MassTransit reads MessageBroker:Host/UserName/Password and applies the explicit credentials over any
 // embedded in the URI, so every broker-bound service is given the same stable host + credentials here.

--- a/src/BuildingBlocks/FreshCart.BuildingBlocks/Exceptions/Handler/CustomExceptionHandler.cs
+++ b/src/BuildingBlocks/FreshCart.BuildingBlocks/Exceptions/Handler/CustomExceptionHandler.cs
@@ -21,12 +21,17 @@ public sealed partial class CustomExceptionHandler(ILogger<CustomExceptionHandle
         ArgumentNullException.ThrowIfNull(httpContext);
         ArgumentNullException.ThrowIfNull(exception);
 
-        LogUnhandledException(
-            exception,
-            exception.GetType().FullName,
-            httpContext.Request.Method,
-            httpContext.Request.Path.ToString(),
-            exception.Message);
+        if (logger.IsEnabled(LogLevel.Error))
+        {
+            var exceptionType = exception.GetType().FullName;
+            var requestPath = httpContext.Request.Path.ToString();
+            LogUnhandledException(
+                exception,
+                exceptionType,
+                httpContext.Request.Method,
+                requestPath,
+                exception.Message);
+        }
 
         var problemDetails = BuildProblemDetails(httpContext, exception);
         httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status500InternalServerError;
@@ -41,6 +46,7 @@ public sealed partial class CustomExceptionHandler(ILogger<CustomExceptionHandle
     [LoggerMessage(
         EventId = 1100,
         Level = LogLevel.Error,
+        SkipEnabledCheck = true,
         Message = "Unhandled exception {ExceptionType} on {RequestMethod} {RequestPath}: {ExceptionMessage}")]
     private partial void LogUnhandledException(
         Exception exception,


### PR DESCRIPTION
﻿Nightly browser tests targeted an undeployed `.local` host. Start the actual Aspire stack and pinned storefront on the runner, wait for dependency readiness, and run two customer journeys in each of three browsers. Use session resources and bounded owned cleanup; explicitly report the absent admin UI. Fix the existing SDK 10 logging analyzer error that blocked AppHost startup and correct local setup documentation.

Validation: AppHost Release build, eight exception-handler tests, five helper checks, actionlint and browser test discovery passed. The six actual browser journeys and hosted-runner resource feasibility remain pending CI; local Docker was unavailable.
