### PR TITLE
fix: initialize Mongo reliably for ephemeral browser tests

### DIFF
--- a/.github/scripts/freshcart-e2e-stack.sh
+++ b/.github/scripts/freshcart-e2e-stack.sh
@@ -78,6 +78,37 @@ new_docker_ids() {
   case "$kind" in containers) docker ps -aq ;; volumes) docker volume ls -q ;; networks) docker network ls -q ;; esac | sort -u | comm -13 "$before_file" -
 }
 
+collect_diagnostics() {
+  local state_dir=$1 diagnostics_dir=$1/diagnostics
+  mkdir -p "$diagnostics_dir"
+  for snapshot in containers.before volumes.before networks.before; do
+    if [[ ! -f "$state_dir/$snapshot" ]]; then
+      echo "Docker ownership snapshot unavailable; no Docker diagnostics collected." > "$diagnostics_dir/README.txt"
+      return 0
+    fi
+  done
+
+  : > "$diagnostics_dir/containers.txt"
+  mapfile -t containers < <(new_docker_ids containers "$state_dir/containers.before")
+  for container in "${containers[@]}"; do
+    docker inspect --format '{{.Name}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" >> "$diagnostics_dir/containers.txt" 2>&1 || true
+    docker logs --tail 80 "$container" > "$diagnostics_dir/container-$container.log" 2>&1 || true
+  done
+
+  : > "$diagnostics_dir/volumes.txt"
+  mapfile -t volumes < <(new_docker_ids volumes "$state_dir/volumes.before")
+  for volume in "${volumes[@]}"; do
+    docker volume inspect --format '{{.Name}} driver={{.Driver}}' "$volume" >> "$diagnostics_dir/volumes.txt" 2>&1 || true
+  done
+
+  : > "$diagnostics_dir/networks.txt"
+  mapfile -t networks < <(new_docker_ids networks "$state_dir/networks.before")
+  for network in "${networks[@]}"; do
+    docker network inspect --format '{{.Name}} driver={{.Driver}}' "$network" >> "$diagnostics_dir/networks.txt" 2>&1 || true
+  done
+  echo "Collected bounded diagnostics for ${#containers[@]} containers, ${#volumes[@]} volumes, and ${#networks[@]} networks." > "$diagnostics_dir/README.txt"
+}
+
 cleanup() {
   local state_dir=$1 pid
   [[ "${CI:-}" == true ]] || { echo "Cleanup is restricted to an isolated CI Docker host" >&2; return 1; }
@@ -107,5 +138,5 @@ cleanup() {
 
 if [[ "${FRESHCART_STACK_LIB_ONLY:-}" != 1 ]]; then
   command_name=${1:-}; shift || true
-  case "$command_name" in preflight) preflight "$@" ;; start) start_stack "$@" ;; wait) wait_for_stack "$@" ;; cleanup) cleanup "$@" ;; *) echo "Usage: $0 {preflight|start|wait|cleanup}" >&2; exit 2 ;; esac
+  case "$command_name" in preflight) preflight "$@" ;; start) start_stack "$@" ;; wait) wait_for_stack "$@" ;; diagnostics) collect_diagnostics "$@" ;; cleanup) cleanup "$@" ;; *) echo "Usage: $0 {preflight|start|wait|diagnostics|cleanup}" >&2; exit 2 ;; esac
 fi

--- a/.github/scripts/freshcart-e2e-stack.sh
+++ b/.github/scripts/freshcart-e2e-stack.sh
@@ -30,7 +30,9 @@ start_stack() {
   snapshot_docker "$state_dir"
   (cd "$backend_dir" && exec setsid env FreshCart__Ephemeral=true dotnet run --project src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj --launch-profile http) > "$state_dir/apphost.log" 2>&1 &
   echo $! > "$state_dir/apphost.pid"
-  (cd "$frontend_dir" && exec setsid npm start -- --host 127.0.0.1 --port 4200) > "$state_dir/storefront.log" 2>&1 &
+  # WebKit rejects Secure cookies on plain HTTP localhost. Keep the production cookie policy
+  # intact and serve the CI storefront over the ephemeral dev certificate instead.
+  (cd "$frontend_dir" && exec setsid npm start -- --host 127.0.0.1 --port 4200 --ssl true) > "$state_dir/storefront.log" 2>&1 &
   echo $! > "$state_dir/storefront.pid"
 }
 
@@ -70,7 +72,7 @@ wait_for_stack() {
   wait_one notification http://localhost:5109/ready
   wait_one reporting http://localhost:5110/ready
   wait_one gateway https://localhost:7100/ready true
-  wait_one storefront http://localhost:4200
+  wait_one storefront https://localhost:4200 true
 }
 
 new_docker_ids() {

--- a/.github/scripts/test-freshcart-e2e-stack.sh
+++ b/.github/scripts/test-freshcart-e2e-stack.sh
@@ -49,4 +49,63 @@ grep -Fx 'volume:new-volume' "$tmp_dir/removals"
 grep -Fx 'network:new-network' "$tmp_dir/removals"
 if grep -F 'existing-' "$tmp_dir/removals"; then echo "cleanup removed a pre-existing resource" >&2; exit 1; fi
 
-echo "freshcart-e2e-stack: 5 checks passed"
+mongo_source="$script_dir/../../src/AspireAppHost/FreshCart.AppHost/Program.cs"
+grep -F 'hello.setName === "rs0" && hello.isWritablePrimary === true' "$mongo_source" >/dev/null
+grep -F 'deadline=$((SECONDS + 600))' "$mongo_source" >/dev/null
+grep -F '&directConnection=true' "$mongo_source" >/dev/null
+grep -F 'ResourceAnnotationMutationBehavior.Replace' "$mongo_source" >/dev/null
+[[ $(grep -c 'RegisterMongoDatabaseHealthCheck' "$mongo_source") -eq 6 ]]
+
+fake_mongosh="$tmp_dir/mongosh"
+cat > "$fake_mongosh" <<'FAKE_MONGOSH'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file=${FAKE_MONGO_STATE:?}
+mode=$(<"$state_file")
+case "$mode" in
+  temporary)
+    printf 'init-attempt\n' >> "${FAKE_MONGO_CALLS:?}"
+    if (( $(wc -l < "${FAKE_MONGO_CALLS:?}") >= 4 )); then printf 'final\n' > "$state_file"; fi
+    exit 1
+    ;;
+  final)
+    if grep -q 'db.hello' <<< "$*"; then exit 0; fi
+    printf 'init-attempt\n' >> "${FAKE_MONGO_CALLS:?}"
+    exit 0
+    ;;
+  timeout)
+    exit 1
+    ;;
+  *) exit 2 ;;
+esac
+FAKE_MONGOSH
+chmod +x "$fake_mongosh"
+
+run_replica_initializer() {
+  local timeout_seconds=$1
+  local deadline=$((SECONDS + timeout_seconds))
+  while (( SECONDS < deadline )); do
+    if "$fake_mongosh" --eval 'const hello = db.hello(); quit(hello.setName === "rs0" && hello.isWritablePrimary === true ? 0 : 1)' >/dev/null 2>&1; then
+      return 0
+    fi
+    "$fake_mongosh" --eval 'try { if (db.hello().setName === "rs0") rs.initiate({_id:"rs0"}); } catch (e) {}' >/dev/null 2>&1 || true
+    sleep 0.1
+  done
+  return 1
+}
+
+printf 'temporary\n' > "$tmp_dir/mongo-state"
+: > "$tmp_dir/mongo-calls"
+export FAKE_MONGO_STATE="$tmp_dir/mongo-state" FAKE_MONGO_CALLS="$tmp_dir/mongo-calls"
+run_replica_initializer 3
+grep -F 'final' "$tmp_dir/mongo-state" >/dev/null
+
+printf 'final\n' > "$tmp_dir/mongo-state"
+: > "$tmp_dir/mongo-calls"
+run_replica_initializer 3
+if [[ -s "$tmp_dir/mongo-calls" ]]; then echo "existing primary was reinitialized" >&2; exit 1; fi
+
+printf 'timeout\n' > "$tmp_dir/mongo-state"
+if run_replica_initializer 1; then echo "replica initializer ignored timeout" >&2; exit 1; fi
+
+echo "freshcart-e2e-stack: 11 checks passed"

--- a/.github/scripts/test-freshcart-e2e-stack.sh
+++ b/.github/scripts/test-freshcart-e2e-stack.sh
@@ -35,12 +35,21 @@ docker() {
   if [[ "$1 $2" == 'ps -aq' ]]; then cat "$tmp_dir/containers.current"
   elif [[ "$1 $2 $3" == 'volume ls -q' ]]; then cat "$tmp_dir/volumes.current"
   elif [[ "$1 $2 $3" == 'network ls -q' ]]; then cat "$tmp_dir/networks.current"
+  elif [[ "$1" == 'inspect' ]]; then printf 'inspect:%s\n' "${*:2}"
+  elif [[ "$1 $2" == 'logs --tail' ]]; then printf 'bounded-log:%s\n' "${*:4}"
+  elif [[ "$1 $2 $3" == 'volume inspect --format' ]]; then printf 'volume-inspect:%s\n' "${*:4}"
+  elif [[ "$1 $2 $3" == 'network inspect --format' ]]; then printf 'network-inspect:%s\n' "${*:4}"
   elif [[ "$1 $2" == 'rm -f' ]]; then printf 'container:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/containers.before" "$tmp_dir/containers.current"
   elif [[ "$1 $2" == 'volume rm' ]]; then printf 'volume:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/volumes.before" "$tmp_dir/volumes.current"
   elif [[ "$1 $2" == 'network rm' ]]; then printf 'network:%s\n' "${*:3}" >> "$tmp_dir/removals"; cp "$state/networks.before" "$tmp_dir/networks.current"
   else return 1
   fi
 }
+collect_diagnostics "$state"
+grep -F 'new-container' "$state/diagnostics/containers.txt" >/dev/null
+if grep -F 'existing-container' "$state/diagnostics/containers.txt" >/dev/null; then echo "diagnostics included a pre-existing container" >&2; exit 1; fi
+[[ -f "$state/diagnostics/container-new-container.log" ]]
+echo "bounded owned Docker diagnostics passed"
 cleanup "$state"
 wait "$owned_group" 2>/dev/null || true
 if kill -0 -- "-$owned_group" 2>/dev/null; then echo "cleanup left its process group running" >&2; exit 1; fi
@@ -50,62 +59,97 @@ grep -Fx 'network:new-network' "$tmp_dir/removals"
 if grep -F 'existing-' "$tmp_dir/removals"; then echo "cleanup removed a pre-existing resource" >&2; exit 1; fi
 
 mongo_source="$script_dir/../../src/AspireAppHost/FreshCart.AppHost/Program.cs"
-grep -F 'hello.setName === "rs0" && hello.isWritablePrimary === true' "$mongo_source" >/dev/null
-grep -F 'deadline=$((SECONDS + 600))' "$mongo_source" >/dev/null
+mongo_initializer="$script_dir/../../src/AspireAppHost/FreshCart.AppHost/mongo-replica-set-init.sh"
+grep -F 'RunAsync().ConfigureAwait(false)' "$mongo_source" >/dev/null
+grep -F 'Replace("\r\n", "\n"' "$mongo_source" >/dev/null
 grep -F '&directConnection=true' "$mongo_source" >/dev/null
 grep -F 'ResourceAnnotationMutationBehavior.Replace' "$mongo_source" >/dev/null
 [[ $(grep -c 'RegisterMongoDatabaseHealthCheck' "$mongo_source") -eq 6 ]]
+grep -F 'status.set && status.set !== "rs0"' "$mongo_initializer" >/dev/null
+grep -F 'error.code === 94' "$mongo_initializer" >/dev/null
+grep -F 'error.code === 76' "$mongo_initializer" >/dev/null
+grep -F 'rs.initiate' "$mongo_initializer" >/dev/null
+grep -F 'FRESHCART_MONGO_INIT_LIB_ONLY' "$mongo_initializer" >/dev/null
+if grep -n $'\r' "$mongo_initializer" >/dev/null; then
+  echo "Mongo initializer must use LF line endings" >&2
+  exit 1
+fi
+echo "production source sanity checks passed"
 
 fake_mongosh="$tmp_dir/mongosh"
 cat > "$fake_mongosh" <<'FAKE_MONGOSH'
 #!/usr/bin/env bash
 set -euo pipefail
 state_file=${FAKE_MONGO_STATE:?}
+calls_file=${FAKE_MONGO_CALLS:?}
 mode=$(<"$state_file")
+eval_script="$*"
+if [[ "$eval_script" == *'rs.initiate'* ]]; then
+  printf 'init\n' >> "$calls_file"
+  if [[ "$mode" == uninitialized ]]; then
+    printf 'primary\n' > "$state_file"
+    exit 0
+  fi
+  exit 1
+fi
+
+printf 'status\n' >> "$calls_file"
 case "$mode" in
   temporary)
-    printf 'init-attempt\n' >> "${FAKE_MONGO_CALLS:?}"
-    if (( $(wc -l < "${FAKE_MONGO_CALLS:?}") >= 4 )); then printf 'final\n' > "$state_file"; fi
-    exit 1
+    status_calls=$(grep -c '^status$' "$calls_file")
+    if (( status_calls >= 2 )); then printf 'uninitialized\n' > "$state_file"; fi
+    exit 76
     ;;
-  final)
-    if grep -q 'db.hello' <<< "$*"; then exit 0; fi
-    printf 'init-attempt\n' >> "${FAKE_MONGO_CALLS:?}"
-    exit 0
-    ;;
-  timeout)
-    exit 1
-    ;;
+  uninitialized) exit 94 ;;
+  primary) exit 0 ;;
+  wrong-set) exit 3 ;;
+  timeout) exit 1 ;;
   *) exit 2 ;;
 esac
 FAKE_MONGOSH
 chmod +x "$fake_mongosh"
 
-run_replica_initializer() {
-  local timeout_seconds=$1
-  local deadline=$((SECONDS + timeout_seconds))
-  while (( SECONDS < deadline )); do
-    if "$fake_mongosh" --eval 'const hello = db.hello(); quit(hello.setName === "rs0" && hello.isWritablePrimary === true ? 0 : 1)' >/dev/null 2>&1; then
-      return 0
-    fi
-    "$fake_mongosh" --eval 'try { if (db.hello().setName === "rs0") rs.initiate({_id:"rs0"}); } catch (e) {}' >/dev/null 2>&1 || true
-    sleep 0.1
-  done
-  return 1
-}
+export PATH="$tmp_dir:$original_path"
+export FRESHCART_MONGO_INIT_LIB_ONLY=1
+source "$mongo_initializer"
+export MONGO_INITDB_ROOT_USERNAME=test MONGO_INITDB_ROOT_PASSWORD=test
+export MONGO_REPLICA_SET_POLL_INTERVAL_SECONDS=0.05
 
 printf 'temporary\n' > "$tmp_dir/mongo-state"
 : > "$tmp_dir/mongo-calls"
 export FAKE_MONGO_STATE="$tmp_dir/mongo-state" FAKE_MONGO_CALLS="$tmp_dir/mongo-calls"
-run_replica_initializer 3
-grep -F 'final' "$tmp_dir/mongo-state" >/dev/null
+MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set
+grep -Fx 'primary' "$tmp_dir/mongo-state" >/dev/null
+grep -Fx 'init' "$tmp_dir/mongo-calls" >/dev/null
+echo "temporary standalone -> uninitialized -> initiated primary passed"
 
-printf 'final\n' > "$tmp_dir/mongo-state"
+printf 'primary\n' > "$tmp_dir/mongo-state"
 : > "$tmp_dir/mongo-calls"
-run_replica_initializer 3
-if [[ -s "$tmp_dir/mongo-calls" ]]; then echo "existing primary was reinitialized" >&2; exit 1; fi
+MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set
+if grep -Fx 'init' "$tmp_dir/mongo-calls" >/dev/null; then
+  echo "existing primary was reinitialized" >&2
+  exit 1
+fi
+echo "existing primary without reinit passed"
+
+printf 'wrong-set\n' > "$tmp_dir/mongo-state"
+: > "$tmp_dir/mongo-calls"
+if MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set >/dev/null 2>&1; then
+  echo "wrong replica set was accepted" >&2
+  exit 1
+fi
+if grep -Fx 'init' "$tmp_dir/mongo-calls" >/dev/null; then
+  echo "wrong replica set was reinitialized" >&2
+  exit 1
+fi
+echo "wrong set failed closed without reinit passed"
 
 printf 'timeout\n' > "$tmp_dir/mongo-state"
-if run_replica_initializer 1; then echo "replica initializer ignored timeout" >&2; exit 1; fi
+: > "$tmp_dir/mongo-calls"
+if MONGO_REPLICA_SET_TIMEOUT_SECONDS=1 initialize_mongo_replica_set >/dev/null 2>&1; then
+  echo "replica initializer ignored deadline" >&2
+  exit 1
+fi
+echo "deadline failure passed"
 
-echo "freshcart-e2e-stack: 11 checks passed"
+echo "freshcart-e2e-stack: production initializer regression checks passed"

--- a/.github/scripts/test-freshcart-e2e-stack.sh
+++ b/.github/scripts/test-freshcart-e2e-stack.sh
@@ -118,14 +118,14 @@ export MONGO_REPLICA_SET_POLL_INTERVAL_SECONDS=0.05
 printf 'temporary\n' > "$tmp_dir/mongo-state"
 : > "$tmp_dir/mongo-calls"
 export FAKE_MONGO_STATE="$tmp_dir/mongo-state" FAKE_MONGO_CALLS="$tmp_dir/mongo-calls"
-MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set
+MONGO_REPLICA_SET_TIMEOUT_SECONDS=30 initialize_mongo_replica_set
 grep -Fx 'primary' "$tmp_dir/mongo-state" >/dev/null
 grep -Fx 'init' "$tmp_dir/mongo-calls" >/dev/null
 echo "temporary standalone -> uninitialized -> initiated primary passed"
 
 printf 'primary\n' > "$tmp_dir/mongo-state"
 : > "$tmp_dir/mongo-calls"
-MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set
+MONGO_REPLICA_SET_TIMEOUT_SECONDS=30 initialize_mongo_replica_set
 if grep -Fx 'init' "$tmp_dir/mongo-calls" >/dev/null; then
   echo "existing primary was reinitialized" >&2
   exit 1
@@ -134,7 +134,7 @@ echo "existing primary without reinit passed"
 
 printf 'wrong-set\n' > "$tmp_dir/mongo-state"
 : > "$tmp_dir/mongo-calls"
-if MONGO_REPLICA_SET_TIMEOUT_SECONDS=3 initialize_mongo_replica_set >/dev/null 2>&1; then
+if MONGO_REPLICA_SET_TIMEOUT_SECONDS=30 initialize_mongo_replica_set >/dev/null 2>&1; then
   echo "wrong replica set was accepted" >&2
   exit 1
 fi

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Verify customer test discovery
         working-directory: tests/e2e
         env:
-          PLAYWRIGHT_BASE_URL: http://localhost:4200
+          PLAYWRIGHT_BASE_URL: https://localhost:4200
         run: |
           mkdir -p test-results
           npx playwright test specs/auth.spec.ts specs/customer-journey.spec.ts --project=${{ matrix.project }} --list | tee test-results/discovery.txt
@@ -105,7 +105,7 @@ jobs:
       - name: Run customer journey gate
         working-directory: tests/e2e
         env:
-          PLAYWRIGHT_BASE_URL: http://localhost:4200
+          PLAYWRIGHT_BASE_URL: https://localhost:4200
         run: npx playwright test specs/auth.spec.ts specs/customer-journey.spec.ts --project=${{ matrix.project }}
 
       - name: Verify executed test count

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -124,6 +124,10 @@ jobs:
           console.log('Verified 2 passing customer tests with 0 skipped.');
           NODE
 
+      - name: Collect bounded owned Docker diagnostics
+        if: always()
+        run: bash .github/scripts/freshcart-e2e-stack.sh diagnostics "$STACK_STATE"
+
       - name: Upload E2E evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -133,6 +137,7 @@ jobs:
             tests/e2e/playwright-report
             tests/e2e/test-results
             ${{ env.STACK_STATE }}/*.log
+            ${{ env.STACK_STATE }}/diagnostics
           retention-days: 14
           if-no-files-found: warn
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -23,7 +23,7 @@ permissions:
 
 env:
   FRONTEND_SHA: acab0f75cf2622566d1edf340ef626d739604958
-  STACK_STATE: ${{ github.workspace }}/.freshcart-e2e
+  STACK_STATE: ${{ github.workspace }}/freshcart-e2e-state
 
 jobs:
   e2e:

--- a/src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj
+++ b/src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.MongoDB" />
     <PackageReference Include="Aspire.Hosting.MySql" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj
+++ b/src/AspireAppHost/FreshCart.AppHost/FreshCart.AppHost.csproj
@@ -25,7 +25,10 @@
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.MongoDB" />
     <PackageReference Include="Aspire.Hosting.MySql" />
-    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="mongo-replica-set-init.sh" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspireAppHost/FreshCart.AppHost/MongoDirectReadinessCheck.cs
+++ b/src/AspireAppHost/FreshCart.AppHost/MongoDirectReadinessCheck.cs
@@ -1,0 +1,52 @@
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace FreshCart.AppHost;
+
+/// <summary>
+/// Checks the authenticated Mongo endpoint without replica-set member discovery.
+/// </summary>
+public sealed class MongoDirectReadinessCheck(
+    ReferenceExpression connectionStringExpression,
+    string databaseName) : IHealthCheck
+{
+    private MongoClient? client;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var connectionString = await connectionStringExpression
+                .GetValueAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return HealthCheckResult.Unhealthy("Mongo connection string is unavailable.");
+            }
+
+            client ??= new MongoClient(connectionString);
+            var hello = await client
+                .GetDatabase(databaseName)
+                .RunCommandAsync<BsonDocument>(new BsonDocument("hello", 1), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            var setName = hello.TryGetValue("setName", out var setNameValue)
+                ? setNameValue.AsString
+                : null;
+            var isWritablePrimary = hello.TryGetValue("isWritablePrimary", out var primaryValue)
+                && primaryValue.IsBoolean
+                && primaryValue.AsBoolean;
+
+            return string.Equals(setName, "rs0", StringComparison.Ordinal) && isWritablePrimary
+                ? HealthCheckResult.Healthy()
+                : HealthCheckResult.Unhealthy("Mongo replica set is not a writable rs0 primary.");
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy("Mongo direct-connection readiness failed.", exception);
+        }
+    }
+}

--- a/src/AspireAppHost/FreshCart.AppHost/Program.cs
+++ b/src/AspireAppHost/FreshCart.AppHost/Program.cs
@@ -1,3 +1,7 @@
+using Aspire.Hosting.ApplicationModel;
+using FreshCart.AppHost;
+using Microsoft.Extensions.DependencyInjection;
+
 // ---------------------------------------------------------------------------
 //  FreshCart.AppHost
 //  Aspire-orchestrated local boot. Backing services start as persistent
@@ -82,14 +86,15 @@ var reportingWarehouse = mysql.AddDatabase("reportingdb")
 // standalone (with auth) and has no replica-set switch, so the container is run as a single-node replica
 // set: a wrapper entrypoint generates the keyfile internal auth requires, hands off to the stock entrypoint
 // (which still creates the admin user) with --replSet + --keyFile, and a backgrounded task runs rs.initiate
-// once mongod answers — idempotent, since rs.status throws only until the set is initiated, so a restart
-// against the persisted volume re-initiates nothing. The single member advertises the container-internal
+// once the final authenticated mongod answers — the retry survives the official image's temporary
+// standalone initdb process, then becomes idempotent because an existing writable primary is accepted.
+// The single member advertises the container-internal
 // host, so service processes connect with directConnection=true (see ReferenceMongoDatabase) and use the
 // seed they are given instead of resolving that host. The script is one line so the C# source's line
-// endings can never put a stray carriage return into the shell command. Verified end-to-end against the
-// mongo:7 image (fresh init, persistent-volume restart, and a committed multi-document transaction).
+// endings can never put a stray carriage return into the shell command. The prior initializer was verified
+// against the mongo:7 image; this retry remains runtime-gated by the hosted E2E run.
 const string MongoReplicaSetInitScript =
-    """KEYFILE=/data/configdb/replica-set.key; if [ ! -f "$KEYFILE" ]; then openssl rand -base64 756 > "$KEYFILE"; chmod 400 "$KEYFILE"; chown mongodb:mongodb "$KEYFILE"; fi; ( until mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval "db.adminCommand({ping:1}).ok" >/dev/null 2>&1; do sleep 0.5; done; mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval 'try { rs.status().ok } catch (e) { rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}) }' ) & exec docker-entrypoint.sh mongod --replSet rs0 --keyFile "$KEYFILE" --bind_ip_all""";
+    """KEYFILE=/data/configdb/replica-set.key; if [ ! -f "$KEYFILE" ]; then openssl rand -base64 756 > "$KEYFILE"; chmod 400 "$KEYFILE"; chown mongodb:mongodb "$KEYFILE"; fi; ( deadline=$((SECONDS + 600)); while (( SECONDS < deadline )); do if mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval 'const hello = db.hello(); quit(hello.setName === "rs0" && hello.isWritablePrimary === true ? 0 : 1)' >/dev/null 2>&1; then break; fi; mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval 'try { if (db.hello().setName === "rs0") rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}); } catch (e) {}' >/dev/null 2>&1 || true; sleep 1; done; if (( SECONDS >= deadline )); then echo "Mongo replica-set primary was not ready before 600s" >&2; exit 1; fi ) & exec docker-entrypoint.sh mongod --replSet rs0 --keyFile "$KEYFILE" --bind_ip_all""";
 
 var mongo = distributedApplicationBuilder
     .AddMongoDB("mongodb")
@@ -111,6 +116,43 @@ var paymentEventStore = mongo.AddDatabase("paymentevents");
 var reviewsDatabase = mongo.AddDatabase("reviewsdb");
 var supportChatTranscripts = mongo.AddDatabase("supportchatdb");
 var notificationsDatabase = mongo.AddDatabase("notificationsdb");
+
+// Aspire.Hosting.MongoDB 9.5.2 builds its server and database health-check clients from the default
+// connection expressions. Mongo advertises the replica-set member as 127.0.0.1:27017, which is the
+// container address rather than the random host-mapped endpoint used by the AppHost. The application
+// services already use directConnection=true; use the same setting for every AppHost health client so
+// WaitFor(database) remains a real authenticated Mongo readiness gate instead of waiting on a wrong
+// discovered member forever.
+const string mongoServerHealthCheck = "mongodb_direct_check";
+var mongoHealthChecks = distributedApplicationBuilder.Services.AddHealthChecks();
+mongoHealthChecks.AddCheck(
+    mongoServerHealthCheck,
+    new MongoDirectReadinessCheck(
+        ReferenceExpression.Create($"{mongo.Resource.ConnectionStringExpression}&directConnection=true"),
+        "admin"));
+mongo.WithAnnotation(
+    new HealthCheckAnnotation(mongoServerHealthCheck),
+    ResourceAnnotationMutationBehavior.Replace);
+
+void RegisterMongoDatabaseHealthCheck(
+    IResourceBuilder<MongoDBDatabaseResource> database,
+    string healthCheckName)
+{
+    mongoHealthChecks.AddCheck(
+        healthCheckName,
+        new MongoDirectReadinessCheck(
+            ReferenceExpression.Create($"{database.Resource.ConnectionStringExpression}&directConnection=true"),
+            database.Resource.DatabaseName));
+    database.WithAnnotation(
+        new HealthCheckAnnotation(healthCheckName),
+        ResourceAnnotationMutationBehavior.Replace);
+}
+
+RegisterMongoDatabaseHealthCheck(deliveryDatabase, "mongodb_delivery_direct_check");
+RegisterMongoDatabaseHealthCheck(paymentEventStore, "mongodb_payment_direct_check");
+RegisterMongoDatabaseHealthCheck(reviewsDatabase, "mongodb_reviews_direct_check");
+RegisterMongoDatabaseHealthCheck(supportChatTranscripts, "mongodb_support_direct_check");
+RegisterMongoDatabaseHealthCheck(notificationsDatabase, "mongodb_notifications_direct_check");
 
 // --- Cache + broker ---------------------------------------------------------
 

--- a/src/AspireAppHost/FreshCart.AppHost/Program.cs
+++ b/src/AspireAppHost/FreshCart.AppHost/Program.cs
@@ -85,16 +85,19 @@ var reportingWarehouse = mysql.AddDatabase("reportingdb")
 // collections in one MongoDB transaction, which a standalone mongod rejects. Aspire's AddMongoDB starts a
 // standalone (with auth) and has no replica-set switch, so the container is run as a single-node replica
 // set: a wrapper entrypoint generates the keyfile internal auth requires, hands off to the stock entrypoint
-// (which still creates the admin user) with --replSet + --keyFile, and a backgrounded task runs rs.initiate
-// once the final authenticated mongod answers — the retry survives the official image's temporary
-// standalone initdb process, then becomes idempotent because an existing writable primary is accepted.
+// (which still creates the admin user) with --replSet + --keyFile, and a backgrounded task runs the
+// packaged initializer once the final authenticated mongod answers. The initializer survives the
+// official image's temporary standalone initdb process, then becomes idempotent because an existing
+// writable primary is accepted.
 // The single member advertises the container-internal
 // host, so service processes connect with directConnection=true (see ReferenceMongoDatabase) and use the
-// seed they are given instead of resolving that host. The script is one line so the C# source's line
-// endings can never put a stray carriage return into the shell command. The prior initializer was verified
-// against the mongo:7 image; this retry remains runtime-gated by the hosted E2E run.
-const string MongoReplicaSetInitScript =
-    """KEYFILE=/data/configdb/replica-set.key; if [ ! -f "$KEYFILE" ]; then openssl rand -base64 756 > "$KEYFILE"; chmod 400 "$KEYFILE"; chown mongodb:mongodb "$KEYFILE"; fi; ( deadline=$((SECONDS + 600)); while (( SECONDS < deadline )); do if mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval 'const hello = db.hello(); quit(hello.setName === "rs0" && hello.isWritablePrimary === true ? 0 : 1)' >/dev/null 2>&1; then break; fi; mongosh --quiet -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --eval 'try { if (db.hello().setName === "rs0") rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]}); } catch (e) {}' >/dev/null 2>&1 || true; sleep 1; done; if (( SECONDS >= deadline )); then echo "Mongo replica-set primary was not ready before 600s" >&2; exit 1; fi ) & exec docker-entrypoint.sh mongod --replSet rs0 --keyFile "$KEYFILE" --bind_ip_all""";
+// seed they are given instead of resolving that host. Normalize the packaged file because the host may
+// be checked out with either repository line-ending setting.
+var mongoReplicaSetInitScript = (await File.ReadAllTextAsync(
+        Path.Combine(AppContext.BaseDirectory, "mongo-replica-set-init.sh"))
+    .ConfigureAwait(false))
+    .Replace("\r\n", "\n", StringComparison.Ordinal)
+    .Replace('\r', '\n');
 
 var mongo = distributedApplicationBuilder
     .AddMongoDB("mongodb")
@@ -103,7 +106,7 @@ var mongo = distributedApplicationBuilder
     {
         context.Args.Clear();
         context.Args.Add("-c");
-        context.Args.Add(MongoReplicaSetInitScript);
+        context.Args.Add(mongoReplicaSetInitScript);
         return Task.CompletedTask;
     });
 if (usePersistentBackingResources)

--- a/src/AspireAppHost/FreshCart.AppHost/mongo-replica-set-init.sh
+++ b/src/AspireAppHost/FreshCart.AppHost/mongo-replica-set-init.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MONGO_REPLICA_SET_NAME="rs0"
+readonly MONGO_REPLICA_SET_MEMBER="127.0.0.1:27017"
+readonly MONGO_REPLICA_SET_KEYFILE="/data/configdb/replica-set.key"
+
+mongo_eval() {
+  mongosh --quiet \
+    -u "$MONGO_INITDB_ROOT_USERNAME" \
+    -p "$MONGO_INITDB_ROOT_PASSWORD" \
+    --authenticationDatabase admin \
+    --eval "$1"
+}
+
+initialize_mongo_replica_set() {
+  local timeout_seconds="${MONGO_REPLICA_SET_TIMEOUT_SECONDS:-600}"
+  local poll_interval="${MONGO_REPLICA_SET_POLL_INTERVAL_SECONDS:-1}"
+  local deadline=$((SECONDS + timeout_seconds))
+  local status_code init_code
+
+  while ((SECONDS < deadline)); do
+    if mongo_eval 'try { const status = rs.status(); if (status.set && status.set !== "rs0") quit(3); quit(status.members?.some(member => member.stateStr === "PRIMARY" && member.health === 1) ? 0 : 1); } catch (error) { quit(error.code === 94 || error.code === 76 ? error.code : 1); }' >/dev/null 2>&1; then
+      return 0
+    else
+      status_code=$?
+    fi
+
+    case "$status_code" in
+      94)
+        if mongo_eval 'try { const status = rs.status(); if (status.set && status.set !== "rs0") quit(3); quit(1); } catch (error) { if (error.code === 94) { const result = rs.initiate({_id: "rs0", members: [{_id: 0, host: "127.0.0.1:27017"}]}); quit(result.ok === 1 ? 0 : 1); } quit(error.code === 76 ? 76 : 1); }' >/dev/null 2>&1; then
+          :
+        else
+          init_code=$?
+          case "$init_code" in
+            0|76) ;;
+            3) echo "Mongo replica-set has an unexpected set identity" >&2; return 1 ;;
+            *) ;;
+          esac
+        fi
+        ;;
+      76|1)
+        ;;
+      3)
+        echo "Mongo replica-set has an unexpected set identity" >&2
+        return 1
+        ;;
+      *)
+        ;;
+    esac
+    sleep "$poll_interval"
+  done
+
+  echo "Mongo replica-set primary was not ready before ${timeout_seconds}s" >&2
+  return 1
+}
+
+prepare_mongo_keyfile() {
+  if [[ ! -f "$MONGO_REPLICA_SET_KEYFILE" ]]; then
+    openssl rand -base64 756 > "$MONGO_REPLICA_SET_KEYFILE"
+    chmod 400 "$MONGO_REPLICA_SET_KEYFILE"
+    chown mongodb:mongodb "$MONGO_REPLICA_SET_KEYFILE"
+  fi
+}
+
+if [[ "${FRESHCART_MONGO_INIT_LIB_ONLY:-}" != 1 ]]; then
+  prepare_mongo_keyfile
+  (initialize_mongo_replica_set) &
+  exec docker-entrypoint.sh mongod \
+    --replSet "$MONGO_REPLICA_SET_NAME" \
+    --keyFile "$MONGO_REPLICA_SET_KEYFILE" \
+    --bind_ip_all
+fi

--- a/src/Services/Reporting/FreshCart.Reporting.Api/FreshCart.Reporting.Api.csproj
+++ b/src/Services/Reporting/FreshCart.Reporting.Api/FreshCart.Reporting.Api.csproj
@@ -11,6 +11,12 @@
     <PackageReference Include="Carter" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- The reporting infrastructure uses Pomelo 9, which requires the EF Core 9 line.
+         Pin the full EF runtime graph in this host so transitive central EF 10 pins cannot
+         load alongside the provider in the same process. Other services keep the central EF 10 pin. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" VersionOverride="9.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" VersionOverride="9.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" VersionOverride="9.0.17" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
     <PackageReference Include="AspNetCore.HealthChecks.MySql" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -14,17 +14,21 @@ dashboard. Runs against any deployed environment — pass the URL via `PLAYWRIGH
 ## Running locally
 
 ```bash
+# In the storefront checkout (keep this process running).
+npm start -- --host 127.0.0.1 --port 4200 --ssl true
+
+# In this checkout.
 cd tests/e2e
 npm ci
 npm run install:browsers
-export PLAYWRIGHT_BASE_URL=http://localhost:4200
+export PLAYWRIGHT_BASE_URL=https://localhost:4200
 npm test
 ```
 
-The CI stack serves the storefront over HTTPS because the session cookie is `Secure` and WebKit
-rejects that cookie on plain HTTP localhost. CI sets `PLAYWRIGHT_BASE_URL=https://localhost:4200`
-and starts Angular with its ephemeral development certificate; Playwright already ignores that
-local certificate. Local HTTP remains the default for manually deployed storefronts.
+The CI stack uses the same HTTPS setup because the session cookie is `Secure` and WebKit rejects
+that cookie on plain HTTP localhost. Playwright already ignores the local development certificate.
+Plain HTTP remains compatible with flows that do not depend on the session cookie, but it cannot
+satisfy this full WebKit authentication suite.
 
 Open the HTML report:
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,6 +21,11 @@ export PLAYWRIGHT_BASE_URL=http://localhost:4200
 npm test
 ```
 
+The CI stack serves the storefront over HTTPS because the session cookie is `Secure` and WebKit
+rejects that cookie on plain HTTP localhost. CI sets `PLAYWRIGHT_BASE_URL=https://localhost:4200`
+and starts Angular with its ephemeral development certificate; Playwright already ignores that
+local certificate. Local HTTP remains the default for manually deployed storefronts.
+
 Open the HTML report:
 
 ```bash

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCi,
   retries: isCi ? 2 : 0,
-  workers: isCi ? 2 : undefined,
+  ...(isCi ? { workers: 2 } : {}),
   // A full cold-stack journey (slow first sign-up, checkout saga, SignalR push) can run well past the
   // default 30s; 120s leaves headroom on a freshly booted, resource-contended environment.
   timeout: 120_000,

--- a/tests/e2e/specs/auth.spec.ts
+++ b/tests/e2e/specs/auth.spec.ts
@@ -18,6 +18,7 @@ test.describe('Authentication — cookie-first sign-in', () => {
     const sessionCookie = cookiesAfterSignUp.find(cookie => cookie.name === 'FreshCart.Session');
     expect(sessionCookie, 'Session cookie must be present after sign-up').toBeDefined();
     expect(sessionCookie?.httpOnly).toBe(true);
+    expect(sessionCookie?.secure).toBe(true);
     expect(sessionCookie?.sameSite?.toLowerCase()).toBe('strict');
 
     // The XSRF-TOKEN companion must also be set (readable so the SPA can echo it).
@@ -26,10 +27,12 @@ test.describe('Authentication — cookie-first sign-in', () => {
     expect(antiForgeryCookie?.httpOnly).toBe(false);
 
     // Act — sign out, then sign in again
-    await page.getByRole('button', { name: /sign out/i }).click();
-    await expect(page.getByRole('link', { name: /sign in/i })).toBeVisible();
+    await customerJourney.signOut();
+    const cookiesAfterSignOut = await context.cookies();
+    expect(cookiesAfterSignOut.find(cookie => cookie.name === 'FreshCart.Session')).toBeUndefined();
 
     await customerJourney.signIn(profile.email, profile.password);
+    await customerJourney.openAccountMenu();
     await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible();
   });
 });

--- a/tests/e2e/specs/support/customer-journey.page.ts
+++ b/tests/e2e/specs/support/customer-journey.page.ts
@@ -34,6 +34,15 @@ export class CustomerJourneyPage {
     await this.expectAuthenticated();
   }
 
+  async signOut(): Promise<void> {
+    await this.openAccountMenu();
+    await this.page.getByRole('button', { name: /sign out/i }).click();
+
+    const accountMenu = this.page.getByTestId('account-menu');
+    await expect(accountMenu).toHaveAttribute('aria-expanded', 'false');
+    await expect(accountMenu).toContainText('Account');
+  }
+
   async addFirstProductToBasket(): Promise<string> {
     await this.page.getByRole('link', { name: /catalog/i }).first().click();
     const firstProductCard = this.page.getByTestId('product-card').first();
@@ -80,8 +89,13 @@ export class CustomerJourneyPage {
     await expect(this.page.getByTestId('notification-toast').first()).toBeVisible({ timeout: 10_000 });
   }
 
-  private async openAccountMenu(): Promise<void> {
-    await this.page.getByTestId('account-menu').click();
+  async openAccountMenu(): Promise<void> {
+    const accountMenu = this.page.getByTestId('account-menu');
+    if (await accountMenu.getAttribute('aria-expanded') !== 'true') {
+      await accountMenu.click();
+    }
+
+    await expect(accountMenu).toHaveAttribute('aria-expanded', 'true');
   }
 
   private async expectAuthenticated(): Promise<void> {


### PR DESCRIPTION
The ephemeral browser-test stack timed out waiting for Payment before any customer journey ran. The Mongo replica initializer could reach the official image's temporary standalone server, and Aspire's Mongo health clients could discover the container-only member address instead of using the mapped host endpoint.

Execute a packaged, bounded replica initializer that retries the temporary standalone state, initializes only an uninitialized replica set, and rejects an unexpected set. Use authenticated direct-connection readiness checks requiring a writable rs0 primary while preserving every WaitFor dependency. Restore observable AppHost startup and collect bounded diagnostics for only test-owned Docker resources into a visible artifact directory.

Validation: strict AppHost build, production initializer regressions, shell/actionlint checks, and Aspire manifest generation pass locally. Local Docker is unavailable. This draft must prove all three browser jobs execute their two customer journeys with zero skips/failures and successful cleanup before merge.
