### PR TITLE
Test rejection of negative pricing discounts

### DIFF
--- a/src/Services/Pricing/FreshCart.Pricing.Tests/Endpoints/CreateCouponRequestValidatorTests.cs
+++ b/src/Services/Pricing/FreshCart.Pricing.Tests/Endpoints/CreateCouponRequestValidatorTests.cs
@@ -55,6 +55,14 @@ public sealed class CreateCouponRequestValidatorTests
     }
 
     [Fact]
+    public void NegativeDiscountValueFails()
+    {
+        var result = _validator.TestValidate(MakeRequest() with { DiscountValue = -0.01m });
+
+        result.ShouldHaveValidationErrorFor(request => request.DiscountValue);
+    }
+
+    [Fact]
     public void PercentageDiscountAboveOneHundredFails()
     {
         var result = _validator.TestValidate(MakeRequest() with

--- a/src/Services/Pricing/FreshCart.Pricing.Tests/Endpoints/CreateDiscountRuleRequestValidatorTests.cs
+++ b/src/Services/Pricing/FreshCart.Pricing.Tests/Endpoints/CreateDiscountRuleRequestValidatorTests.cs
@@ -55,6 +55,14 @@ public sealed class CreateDiscountRuleRequestValidatorTests
     }
 
     [Fact]
+    public void NegativePercentageFails()
+    {
+        var result = _validator.TestValidate(MakeRequest() with { DiscountPercentage = -0.01m });
+
+        result.ShouldHaveValidationErrorFor(request => request.DiscountPercentage);
+    }
+
+    [Fact]
     public void PercentageAboveOneHundredFails()
     {
         var result = _validator.TestValidate(MakeRequest() with { DiscountPercentage = 100.01m });


### PR DESCRIPTION
Fixes #5.

Adds regression coverage showing that negative coupon values and discount percentages are rejected by the existing pricing validators.

Validation: 55 Pricing tests pass locally. Hosted Pricing build/tests, Docker/Trivy, CodeQL, SonarCloud and real checkout Playwright tests in Chromium, Firefox and WebKit all pass at 495de14c4d16e915fed804f847c91ec309418169. Root independently reviewed the two-test diff; no validation rules or gates changed.
