### PR TITLE
fix(delivery): validate postal formats before checkout

### DIFF
--- a/src/BuildingBlocks/FreshCart.BuildingBlocks.Tests/Addressing/PostalCodeFormatPolicyTests.cs
+++ b/src/BuildingBlocks/FreshCart.BuildingBlocks.Tests/Addressing/PostalCodeFormatPolicyTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using FreshCart.BuildingBlocks.Addressing;
+
+namespace FreshCart.BuildingBlocks.Tests.Addressing;
+
+public sealed class PostalCodeFormatPolicyTests
+{
+    [Theory]
+    [InlineData("GB", "W1K 7TN")]
+    [InlineData("US", "00501")]
+    [InlineData("IE", "D04 K7X4")]
+    [InlineData("DE", "10115")]
+    [InlineData("FR", "75001")]
+    [InlineData("AU", "2000")]
+    public void AcceptsTheSupportedNationalPostalShapes(string countryCode, string postalCode)
+    {
+        PostalCodeFormatPolicy.IsValid(countryCode, postalCode).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("GB", "12345")]
+    [InlineData("US", "1234")]
+    [InlineData("IE", "D04- K7X4")]
+    [InlineData("DE", "1011")]
+    [InlineData("FR", "7500A")]
+    [InlineData("AU", "20000")]
+    public void RejectsMalformedNationalPostalShapes(string countryCode, string postalCode)
+    {
+        PostalCodeFormatPolicy.IsValid(countryCode, postalCode).Should().BeFalse();
+    }
+
+    [Fact]
+    public void LeavesUnknownCountryCodesToTheirExistingGenericValidation()
+    {
+        PostalCodeFormatPolicy.IsValid("LK", "00100").Should().BeTrue();
+    }
+}

--- a/src/BuildingBlocks/FreshCart.BuildingBlocks.Tests/Addressing/PostalCodeFormatPolicyTests.cs
+++ b/src/BuildingBlocks/FreshCart.BuildingBlocks.Tests/Addressing/PostalCodeFormatPolicyTests.cs
@@ -7,6 +7,7 @@ public sealed class PostalCodeFormatPolicyTests
 {
     [Theory]
     [InlineData("GB", "W1K 7TN")]
+    [InlineData("GB", "SW1A1AA")]
     [InlineData("US", "00501")]
     [InlineData("IE", "D04 K7X4")]
     [InlineData("DE", "10115")]
@@ -24,6 +25,9 @@ public sealed class PostalCodeFormatPolicyTests
     [InlineData("DE", "1011")]
     [InlineData("FR", "7500A")]
     [InlineData("AU", "20000")]
+    [InlineData("US", "１２３４５")]
+    [InlineData("US", "١٢٣٤٥")]
+    [InlineData("GB", "SW1A\n1AA")]
     public void RejectsMalformedNationalPostalShapes(string countryCode, string postalCode)
     {
         PostalCodeFormatPolicy.IsValid(countryCode, postalCode).Should().BeFalse();

--- a/src/BuildingBlocks/FreshCart.BuildingBlocks/Addressing/PostalCodeFormatPolicy.cs
+++ b/src/BuildingBlocks/FreshCart.BuildingBlocks/Addressing/PostalCodeFormatPolicy.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace FreshCart.BuildingBlocks.Addressing;
+
+/// <summary>
+/// Checks the structural shape of postal codes for the countries currently offered by the storefront.
+/// Unknown country codes remain governed by the caller's generic length and required-value rules until a
+/// country-specific format is deliberately added.
+/// </summary>
+public static partial class PostalCodeFormatPolicy
+{
+    /// <summary>
+    /// Returns whether the postal code has the expected national shape for a known country code.
+    /// This checks formatting only; it does not verify that a code exists or belongs to the address.
+    /// </summary>
+    public static bool IsValid(string countryCode, string postalCode)
+    {
+        if (string.IsNullOrWhiteSpace(countryCode) || string.IsNullOrWhiteSpace(postalCode))
+        {
+            return false;
+        }
+
+        var normalisedCountryCode = countryCode.Trim().ToUpperInvariant();
+        var candidate = postalCode.Trim();
+
+        return normalisedCountryCode switch
+        {
+            "GB" => UnitedKingdomRegex().IsMatch(candidate),
+            "US" => UnitedStatesRegex().IsMatch(candidate),
+            "IE" => IrelandRegex().IsMatch(candidate),
+            "DE" or "FR" => FiveDigitNumericRegex().IsMatch(candidate),
+            "AU" => FourDigitNumericRegex().IsMatch(candidate),
+            _ => true,
+        };
+    }
+
+    [GeneratedRegex(@"^(?:(?:[A-Z]{1,2}\d[A-Z\d]?)|GIR)\s{1,2}\d[A-Z]{2}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    private static partial Regex UnitedKingdomRegex();
+
+    [GeneratedRegex(@"^\d{5}(?:-\d{4})?$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    private static partial Regex UnitedStatesRegex();
+
+    [GeneratedRegex(@"^(?:[A-Z]\d{2}|D6W)\s?[A-Z0-9]{4}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    private static partial Regex IrelandRegex();
+
+    [GeneratedRegex(@"^\d{5}$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    private static partial Regex FiveDigitNumericRegex();
+
+    [GeneratedRegex(@"^\d{4}$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    private static partial Regex FourDigitNumericRegex();
+}

--- a/src/BuildingBlocks/FreshCart.BuildingBlocks/Addressing/PostalCodeFormatPolicy.cs
+++ b/src/BuildingBlocks/FreshCart.BuildingBlocks/Addressing/PostalCodeFormatPolicy.cs
@@ -6,6 +6,15 @@ namespace FreshCart.BuildingBlocks.Addressing;
 /// Checks the structural shape of postal codes for the countries currently offered by the storefront.
 /// Unknown country codes remain governed by the caller's generic length and required-value rules until a
 /// country-specific format is deliberately added.
+/// The national shape references are the UPU Postal Addressing Systems (Germany and France), GOV.UK
+/// postcode input guidance, USPS Web Tools and ZIP Code guidance, the official Eircode Code of Practice,
+/// and Australia Post's postcode data guide:
+/// https://www.upu.int/en/Postal-Solutions/Programmes-Services/Addressing-Solutions,
+/// https://design-system.service.gov.uk/components/text-input/,
+/// https://www.usps.com/business/web-tools-apis/address-information-api.htm,
+/// https://faq.usps.com/articles/Knowledge/ZIP-Code-The-Basics,
+/// https://www.eircode.ie/docs/default-source/common/code-of-practice-version-7b23930b5-1cbd-4b89-bafe-bcd6f72438f8.pdf,
+/// https://auspost.com.au/content/dam/auspost_corp/media/documents/online-self-service-products-data-guide.pdf.
 /// </summary>
 public static partial class PostalCodeFormatPolicy
 {
@@ -34,18 +43,18 @@ public static partial class PostalCodeFormatPolicy
         };
     }
 
-    [GeneratedRegex(@"^(?:(?:[A-Z]{1,2}\d[A-Z\d]?)|GIR)\s{1,2}\d[A-Z]{2}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    [GeneratedRegex(@"\A(?:(?:[A-Z]{1,2}[0-9][A-Z0-9]?)|GIR) ?[0-9][A-Z]{2}\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
     private static partial Regex UnitedKingdomRegex();
 
-    [GeneratedRegex(@"^\d{5}(?:-\d{4})?$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    [GeneratedRegex(@"\A[0-9]{5}(?:-[0-9]{4})?\z", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
     private static partial Regex UnitedStatesRegex();
 
-    [GeneratedRegex(@"^(?:[A-Z]\d{2}|D6W)\s?[A-Z0-9]{4}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    [GeneratedRegex(@"\A(?:[A-Z][0-9]{2}|D6W) ?[A-Z0-9]{4}\z", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
     private static partial Regex IrelandRegex();
 
-    [GeneratedRegex(@"^\d{5}$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    [GeneratedRegex(@"\A[0-9]{5}\z", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
     private static partial Regex FiveDigitNumericRegex();
 
-    [GeneratedRegex(@"^\d{4}$", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
+    [GeneratedRegex(@"\A[0-9]{4}\z", RegexOptions.CultureInvariant | RegexOptions.NonBacktracking)]
     private static partial Regex FourDigitNumericRegex();
 }

--- a/src/Services/Basket/FreshCart.Basket.Api/Features/ShoppingBaskets/Checkout/CheckoutAddressValidator.cs
+++ b/src/Services/Basket/FreshCart.Basket.Api/Features/ShoppingBaskets/Checkout/CheckoutAddressValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using FreshCart.BuildingBlocks.Addressing;
 using FreshCart.BuildingBlocks.Messaging.IntegrationEvents;
 
 namespace FreshCart.Basket.Api.Features.ShoppingBaskets.Checkout;
@@ -25,7 +26,9 @@ public sealed class CheckoutAddressValidator : AbstractValidator<CheckoutAddress
 
         RuleFor(address => address.PostalCode)
             .NotEmpty()
-            .MaximumLength(MaxPostalCodeLength);
+            .MaximumLength(MaxPostalCodeLength)
+            .Must((address, postalCode) => PostalCodeFormatPolicy.IsValid(address.CountryCode, postalCode))
+            .WithMessage("Postal code format is invalid for the selected country.");
 
         RuleFor(address => address.CountryCode)
             .NotEmpty()

--- a/src/Services/Basket/FreshCart.Basket.Tests/Features/Checkout/CheckoutAddressValidatorTests.cs
+++ b/src/Services/Basket/FreshCart.Basket.Tests/Features/Checkout/CheckoutAddressValidatorTests.cs
@@ -64,6 +64,34 @@ public sealed class CheckoutAddressValidatorTests
     }
 
     [Theory]
+    [InlineData("GB", "W1K 7TN")]
+    [InlineData("US", "00501-1234")]
+    [InlineData("IE", "D04 K7X4")]
+    [InlineData("DE", "10115")]
+    [InlineData("FR", "75001")]
+    [InlineData("AU", "2000")]
+    public void SupportedCountryPostalShapesPass(string countryCode, string postalCode)
+    {
+        var result = _validator.TestValidate(ValidAddress with { CountryCode = countryCode, PostalCode = postalCode });
+
+        result.ShouldNotHaveValidationErrorFor(address => address.PostalCode);
+    }
+
+    [Theory]
+    [InlineData("GB", "12345")]
+    [InlineData("US", "1234")]
+    [InlineData("IE", "D04- K7X4")]
+    [InlineData("DE", "1011")]
+    [InlineData("FR", "7500A")]
+    [InlineData("AU", "20000")]
+    public void MalformedSupportedCountryPostalShapesFail(string countryCode, string postalCode)
+    {
+        var result = _validator.TestValidate(ValidAddress with { CountryCode = countryCode, PostalCode = postalCode });
+
+        result.ShouldHaveValidationErrorFor(address => address.PostalCode);
+    }
+
+    [Theory]
     [InlineData("L")]
     [InlineData("LKA")]
     public void CountryCodeMustBeTwoLetters(string countryCode)

--- a/src/Services/Delivery/FreshCart.Delivery.Domain/Deliveries/DeliveryAddress.cs
+++ b/src/Services/Delivery/FreshCart.Delivery.Domain/Deliveries/DeliveryAddress.cs
@@ -1,3 +1,5 @@
+using FreshCart.BuildingBlocks.Addressing;
+
 namespace FreshCart.Delivery.Domain.Deliveries;
 
 /// <summary>
@@ -12,6 +14,10 @@ public sealed record DeliveryAddress
         ArgumentException.ThrowIfNullOrWhiteSpace(city);
         ArgumentException.ThrowIfNullOrWhiteSpace(postalCode);
         ArgumentException.ThrowIfNullOrWhiteSpace(countryCode);
+        if (!PostalCodeFormatPolicy.IsValid(countryCode, postalCode))
+        {
+            throw new ArgumentException("Postal code format is invalid for the selected country.", nameof(postalCode));
+        }
 
         Line1 = line1;
         Line2 = line2;

--- a/src/Services/Delivery/FreshCart.Delivery.Tests/Domain/DeliveryTests.cs
+++ b/src/Services/Delivery/FreshCart.Delivery.Tests/Domain/DeliveryTests.cs
@@ -69,6 +69,20 @@ public sealed class DeliveryTests
         failure.Should().Throw<DomainException>().WithMessage("*cannot be failed*");
     }
 
+    [Theory]
+    [InlineData("GB", "12345")]
+    [InlineData("US", "1234")]
+    [InlineData("IE", "D04- K7X4")]
+    [InlineData("DE", "1011")]
+    [InlineData("FR", "7500A")]
+    [InlineData("AU", "20000")]
+    public void ADeliveryAddressRejectsMalformedSupportedCountryPostalShapes(string countryCode, string postalCode)
+    {
+        var creation = () => new DeliveryAddress("12 Market Street", null, "London", postalCode, countryCode);
+
+        creation.Should().Throw<ArgumentException>().WithParameterName(nameof(postalCode));
+    }
+
     private static DeliveryAggregate CreateScheduledDelivery() => DeliveryAggregate.Schedule(
         Guid.NewGuid(),
         Guid.NewGuid(),


### PR DESCRIPTION
Fixes #6.

Validate postal-code shape for the storefront's GB, US, IE, DE, FR and AU addresses before checkout publishes an event, with a matching Delivery domain guard. Other countries retain the existing generic validation. This checks format, not whether an address exists. Compact UK codes remain accepted; Unicode digits and embedded line breaks are rejected.

Validation: 63 BuildingBlocks tests, 20 Basket address tests and 11 Delivery domain tests pass locally; Basket and Delivery Release builds pass without warnings. The full local Basket suite could not run its Testcontainers case because Docker is unavailable locally; hosted Docker tests and E2E must pass before merge. Existing persisted malformed supported-country postal codes would now fail the domain constructor; this is intentional validation tightening.

Final hosted validation at 2e666bf7e30fd8291975c6d9d6c35445c8c5a7ad: all service build/test and Docker security checks, CodeQL, SonarCloud, and Chromium/Firefox/WebKit checkout E2E pass. Basket 104/104 and Delivery 70/70 tests pass with zero skipped. Root independently reviewed the policy, callers and regressions.
