### PR TITLE
feat(customersupport): document the API with development Swagger UI

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -91,7 +91,7 @@ jobs:
         run: bash .github/scripts/freshcart-e2e-stack.sh wait "$STACK_STATE" 600
 
       - name: Report admin surface availability
-        run: echo 'Admin E2E unavailable — this repository set has no admin SPA. The reporting-dashboard spec remains in source and is excluded from this customer-storefront gate.' | tee -a "$GITHUB_STEP_SUMMARY"
+        run: echo 'Dedicated reporting-dashboard E2E is outside this customer-storefront gate; the embedded /dashboard and /support/console routes remain in the storefront.' | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Verify customer test discovery
         working-directory: tests/e2e
@@ -123,6 +123,57 @@ jobs:
           }
           console.log('Verified 2 passing customer tests with 0 skipped.');
           NODE
+
+      - name: Capture Customer Support OpenAPI evidence
+        if: matrix.project == 'chromium'
+        working-directory: tests/e2e
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_root="test-results/support-docs"
+          base_url="https://localhost:7111"
+          mkdir -p "$evidence_root"
+
+          capture() {
+            local relative_path="$1"
+            local body_path="$evidence_root/$relative_path"
+            local header_path="${body_path}.headers"
+            local response_code
+
+            mkdir -p "$(dirname "$body_path")"
+            if ! response_code="$(curl -kfsS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --dump-header "$header_path" \
+              --output "$body_path" \
+              --write-out '%{http_code}' \
+              "$base_url/$relative_path")"; then
+              echo "Customer Support evidence request failed: /$relative_path" >&2
+              return 1
+            fi
+
+            if [[ "$response_code" != 2* ]]; then
+              echo "Customer Support evidence request returned HTTP $response_code: /$relative_path" >&2
+              return 1
+            fi
+          }
+
+          capture swagger/index.html
+          capture swagger/swagger-ui.css
+          capture swagger/swagger-ui-bundle.js
+          capture swagger/swagger-ui-standalone-preset.js
+          capture swagger/index.js
+          capture swagger/favicon-16x16.png
+          capture swagger/favicon-32x32.png
+          capture openapi/v1.json
+
+          {
+            printf 'backend_sha=%s\n' '${{ github.sha }}'
+            printf 'frontend_sha=%s\n' '${{ env.FRONTEND_SHA }}'
+            printf 'run_id=%s\n' '${{ github.run_id }}'
+            printf 'captured_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            printf 'base_url=%s\n' "$base_url"
+          } > "$evidence_root/capture-metadata.txt"
 
       - name: Collect bounded owned Docker diagnostics
         if: always()

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  FRONTEND_SHA: acab0f75cf2622566d1edf340ef626d739604958
+  FRONTEND_SHA: 40ed245bb6937db582bf2e9eb59e79c675614793
   STACK_STATE: ${{ github.workspace }}/freshcart-e2e-state
 
 jobs:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <!-- 10.0.9 servicing line clears CVE-2026-40372 (DataProtection). Cryptography.Xml is NOT
          cleared at 10.0.9 and is pinned separately below. -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <!-- Transitive pin: Microsoft.AspNetCore.OpenApi 10.0.9 floors Microsoft.OpenApi at 2.0.0,
          which carries GHSA-v5pm-xwqc-g5wc (stack-overflow DoS on circular schema refs). Fixed in 2.7.5+. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />

--- a/README.md
+++ b/README.md
@@ -49,15 +49,23 @@ cd freshcart-web && npm ci && npm start
 
 | Surface | URL | What it shows |
 |---|---|---|
-| **Customer storefront** | http://localhost:4200 | Catalog, basket, checkout, orders, support chat, real-time notifications |
+| **Customer storefront** | https://localhost:4200 | Catalog, basket, checkout, orders, support chat, real-time notifications |
 | **Aspire dashboard** | http://localhost:15888 | Every service + live traces, metrics, logs |
 | **YARP API Gateway** | https://localhost:7100 | Single public edge; cookie-to-JWT BFF exchange |
 | **Identity API** (OpenAPI) | https://localhost:7101 | Sign-up, sign-in, refresh, MFA enrollment |
+| **Customer Support API** (development Swagger UI) | https://localhost:7111/swagger | OpenAPI schema exploration; support operations still require a JWT |
 | **Reporting API** (OpenAPI) | https://localhost:7110 | Dashboards, invoices, Excel exports |
 | **Seq** (logs) | http://localhost:5341 | Structured logs across every service |
 | **Grafana** (metrics) | http://localhost:3000 | RED + USE dashboards (`admin / freshcart_local_dev`) |
 | **Prometheus** | http://localhost:9090 | Raw metric store |
 | **RabbitMQ management** | http://localhost:15672 | Queues + exchanges (`freshcart / freshcart_local_dev`) |
+
+Customer Support exposes its OpenAPI surface locally during Development:
+
+- `https://localhost:7111/swagger` serves the self-hosted Swagger UI assets.
+- `https://localhost:7111/openapi/v1.json` serves the generated document consumed by that UI.
+- The document endpoint is available for local schema exploration; support operations remain protected by their configured JWT policies. The UI does not mint or supply credentials.
+- `GET /support/sessions/active` returns `ChatSessionDto` values; `GET /support/sessions` returns a paginated `ChatSessionDto` envelope; and `GET /support/sessions/{sessionId}/messages` returns a paginated `ChatMessageDto` envelope.
 
 ### Sign in with one of the seeded accounts
 
@@ -77,7 +85,7 @@ cd freshcart-web && npm ci && npm start
 
 ### 90-second guided tour after sign-in
 
-1. Open <http://localhost:4200> &rarr; sign in as `demo@freshcart.test`.
+1. Open <https://localhost:4200> &rarr; sign in as `demo@freshcart.test`.
 2. Browse the catalog (30 seeded products across 8 categories), add three items to the basket.
 3. Check out &mdash; accept the default address. The Ordering saga drives stock reservation,
    payment capture, and delivery booking.

--- a/docs/FreshCart_Architecture_Guide.html
+++ b/docs/FreshCart_Architecture_Guide.html
@@ -267,9 +267,9 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
         <p style="font-size:.78rem;">Sign in &rarr; browse catalog &rarr; basket &rarr; checkout &rarr; receive a SignalR notification.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--purple);">
-        <h4>Admin back-office</h4>
-        <p><a href="http://localhost:4300" target="_blank"><code>http://localhost:4300</code></a></p>
-        <p style="font-size:.78rem;">KPI dashboards, invoices, sales exports, stock management, support chat console.</p>
+        <h4>Back-office routes (same SPA, role-gated)</h4>
+        <p><a href="https://localhost:4200/dashboard" target="_blank"><code>https://localhost:4200/dashboard</code></a></p>
+        <p style="font-size:.78rem;">The Administrator/Manager dashboard and SupportAgent support console are embedded in the customer storefront.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--accent);">
         <h4>Aspire dashboard</h4>

--- a/docs/FreshCart_Architecture_Guide.html
+++ b/docs/FreshCart_Architecture_Guide.html
@@ -263,7 +263,7 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
     <div class="card-grid">
       <div class="mini-card" style="border-left:4px solid var(--green);">
         <h4>Customer storefront</h4>
-        <p><a href="http://localhost:4200" target="_blank"><code>http://localhost:4200</code></a></p>
+        <p><a href="https://localhost:4200" target="_blank"><code>https://localhost:4200</code></a></p>
         <p style="font-size:.78rem;">Sign in &rarr; browse catalog &rarr; basket &rarr; checkout &rarr; receive a SignalR notification.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--purple);">
@@ -341,7 +341,7 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
 
     <h3 style="margin-top:1.2rem;">90-second guided tour after sign-in</h3>
     <ol class="steps">
-      <li>Open <a href="http://localhost:4200" target="_blank">http://localhost:4200</a> &rarr; sign in as <code>demo@freshcart.test</code>.</li>
+      <li>Open <a href="https://localhost:4200" target="_blank">https://localhost:4200</a> &rarr; sign in as <code>demo@freshcart.test</code>.</li>
       <li>Browse the catalog (seeded with 30 sample products across 8 categories), add three items to the basket.</li>
       <li>Check out &mdash; accept the default address. Watch the saga progress through stock reservation, payment capture and delivery booking.</li>
       <li>A toast notification appears in the top-right within ~1 second (SignalR push from <code>NotificationHub</code> via Redis backplane).</li>
@@ -1377,7 +1377,7 @@ dotnet run --project src/Services/Identity/FreshCart.Identity.Api
 git clone https://github.com/amasen02/freshcart-web.git
 cd freshcart-web
 npm install
-npm start                     # http://localhost:4200
+npm start                     # https://localhost:4200
 
 # 5. Run the full test suite
 dotnet test src/FreshCart.sln

--- a/index.html
+++ b/index.html
@@ -267,9 +267,9 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
         <p style="font-size:.78rem;">Sign in &rarr; browse catalog &rarr; basket &rarr; checkout &rarr; receive a SignalR notification.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--purple);">
-        <h4>Back-office (same SPA, role-gated)</h4>
+        <h4>Back-office routes (same SPA, role-gated)</h4>
         <p><a href="https://localhost:4200/dashboard" target="_blank"><code>https://localhost:4200/dashboard</code></a></p>
-        <p style="font-size:.78rem;">KPI dashboards, invoices, sales exports, stock management, support agent console. Visible to Administrator, Manager and SupportAgent roles.</p>
+        <p style="font-size:.78rem;">The Administrator/Manager dashboard and SupportAgent support console are embedded in the customer storefront.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--accent);">
         <h4>Aspire dashboard</h4>

--- a/index.html
+++ b/index.html
@@ -263,12 +263,12 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
     <div class="card-grid">
       <div class="mini-card" style="border-left:4px solid var(--green);">
         <h4>Customer storefront</h4>
-        <p><a href="http://localhost:4200" target="_blank"><code>http://localhost:4200</code></a></p>
+        <p><a href="https://localhost:4200" target="_blank"><code>https://localhost:4200</code></a></p>
         <p style="font-size:.78rem;">Sign in &rarr; browse catalog &rarr; basket &rarr; checkout &rarr; receive a SignalR notification.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--purple);">
         <h4>Back-office (same SPA, role-gated)</h4>
-        <p><a href="http://localhost:4200/dashboard" target="_blank"><code>http://localhost:4200/dashboard</code></a></p>
+        <p><a href="https://localhost:4200/dashboard" target="_blank"><code>https://localhost:4200/dashboard</code></a></p>
         <p style="font-size:.78rem;">KPI dashboards, invoices, sales exports, stock management, support agent console. Visible to Administrator, Manager and SupportAgent roles.</p>
       </div>
       <div class="mini-card" style="border-left:4px solid var(--accent);">
@@ -341,7 +341,7 @@ cd freshcart-web &amp;&amp; npm install &amp;&amp; npm start</code></pre>
 
     <h3 style="margin-top:1.2rem;">90-second guided tour after sign-in</h3>
     <ol class="steps">
-      <li>Open <a href="http://localhost:4200" target="_blank">http://localhost:4200</a> &rarr; sign in as <code>demo@freshcart.test</code>.</li>
+      <li>Open <a href="https://localhost:4200" target="_blank">https://localhost:4200</a> &rarr; sign in as <code>demo@freshcart.test</code>.</li>
       <li>Browse the catalog (seeded with 24 digital products across 6 categories), add three items to the basket.</li>
       <li>Check out &mdash; accept the default address. Watch the saga progress through stock reservation and payment capture, then order confirmation.</li>
       <li>A toast notification appears in the top-right within ~1 second (SignalR push from <code>NotificationHub</code> via Redis backplane).</li>
@@ -1402,7 +1402,7 @@ dotnet run --project src/Services/Identity/FreshCart.Identity.Api
 git clone https://github.com/amasen02/freshcart-web.git
 cd freshcart-web
 npm install
-npm start                     # http://localhost:4200
+npm start                     # https://localhost:4200
 
 # 5. Run the full test suite
 dotnet test src/FreshCart.sln

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/DevelopmentSwaggerUi.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/DevelopmentSwaggerUi.cs
@@ -5,12 +5,15 @@ namespace FreshCart.CustomerSupport.Api;
 
 /// <summary>
 /// Development-only Swagger UI wiring. The document remains the ASP.NET Core OpenAPI document, while
-/// this UI package supplies only static browser assets and a self-hosted initializer.
+/// this UI package supplies only static browser assets and a self-hosted initializer. Swashbuckle
+/// 10.2.3's bundled logo SVG emits one version-pinned inline style block, whose SHA-256 is allowlisted
+/// below using the CSP style-src hash syntax documented at https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src.
 /// </summary>
 internal static class DevelopmentSwaggerUi
 {
+    // Keep this hash synchronized with the version-pinned Swashbuckle 10.2.3 logo SVG style.
     private const string SwaggerCsp =
-        "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; "
+        "default-src 'none'; script-src 'self'; style-src 'self' 'sha256-RL3ie0nH+Lzz2YNqQN83mnU0J1ot4QL7b99vMdIX99w='; img-src 'self' data:; "
         + "connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
     private const string IndexHtml = """

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/DevelopmentSwaggerUi.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/DevelopmentSwaggerUi.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+
+namespace FreshCart.CustomerSupport.Api;
+
+/// <summary>
+/// Development-only Swagger UI wiring. The document remains the ASP.NET Core OpenAPI document, while
+/// this UI package supplies only static browser assets and a self-hosted initializer.
+/// </summary>
+internal static class DevelopmentSwaggerUi
+{
+    private const string SwaggerCsp =
+        "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; "
+        + "connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+
+    private const string IndexHtml = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>FreshCart Customer Support API</title>
+            <link rel="stylesheet" href="./swagger-ui.css">
+            <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
+            <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">
+        </head>
+        <body>
+            <div id="swagger-ui"></div>
+            <script src="./swagger-ui-bundle.js" charset="utf-8"></script>
+            <script src="./swagger-ui-standalone-preset.js" charset="utf-8"></script>
+            <script src="./index.js" charset="utf-8"></script>
+        </body>
+        </html>
+        """;
+
+    public static void Use(IApplicationBuilder application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        application.Use(async (httpContext, next) =>
+        {
+            if (httpContext.Request.Path.StartsWithSegments("/swagger", StringComparison.OrdinalIgnoreCase))
+            {
+                httpContext.Response.OnStarting(() =>
+                {
+                    httpContext.Response.Headers["Content-Security-Policy"] = SwaggerCsp;
+                    return Task.CompletedTask;
+                });
+            }
+
+            await next().ConfigureAwait(false);
+        });
+
+        application.UseSwaggerUI(options =>
+        {
+            options.SwaggerEndpoint("/openapi/v1.json", "FreshCart Customer Support API");
+            options.ConfigObject.ValidatorUrl = null;
+            options.DocumentTitle = "FreshCart Customer Support API";
+            options.IndexStream = () => new MemoryStream(Encoding.UTF8.GetBytes(IndexHtml));
+        });
+    }
+}

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/FreshCart.CustomerSupport.Api.csproj
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/FreshCart.CustomerSupport.Api.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Carter" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
     <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="StackExchange.Redis" />

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/Program.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Api/Program.cs
@@ -90,6 +90,7 @@ application.UseExceptionHandler();
 if (application.Environment.IsDevelopment())
 {
     application.MapOpenApi();
+    DevelopmentSwaggerUi.Use(application);
 }
 else
 {

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportApiFactory.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportApiFactory.cs
@@ -28,13 +28,20 @@ public sealed class SupportApiFactory : WebApplicationFactory<Program>
     private const string Audience = "https://freshcart.test";
     private const string SigningKey = "customer-support-endpoint-integration-test-signing-key";
 
+    public string EnvironmentName { get; set; } = "Development";
+
     public InMemoryChatSessionRepository Sessions { get; } = new();
 
     public InMemoryChatMessageRepository Messages { get; } = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        builder.UseEnvironment("Development");
+        builder.UseEnvironment(EnvironmentName);
+        builder.UseSetting("ConnectionStrings:supportchatdb", "mongodb://localhost:27017/freshcart_support_endpoint_tests");
+        builder.UseSetting("ConnectionStrings:cache", "localhost:6379");
+        builder.UseSetting("Jwt:Issuer", Issuer);
+        builder.UseSetting("Jwt:Audience", Audience);
+        builder.UseSetting("Jwt:SigningKey", SigningKey);
 
         builder.ConfigureAppConfiguration((_, configurationBuilder) =>
             configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
@@ -295,7 +295,7 @@ public sealed class SupportEndpointsTests(SupportApiFactory factory) : IClassFix
     }
 
     private const string StrictApiCsp = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
-    private const string SwaggerCsp = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+    private const string SwaggerCsp = "default-src 'none'; script-src 'self'; style-src 'self' 'sha256-RL3ie0nH+Lzz2YNqQN83mnU0J1ot4QL7b99vMdIX99w='; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
     private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string uri, Guid userId, string role)
     {

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using FluentAssertions;
 using FreshCart.CustomerSupport.Api.Domain;
 using Xunit;
@@ -121,6 +122,41 @@ public sealed class SupportEndpointsTests(SupportApiFactory factory) : IClassFix
         var response = await SendAsync(HttpMethod.Get, "/support/sessions/", Guid.NewGuid(), AdministratorRole);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task OpenApiDescribesSupportEndpointsAndResponseSchemas()
+    {
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/openapi/v1.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var documentStream = await response.Content.ReadAsStreamAsync();
+        using var document = await JsonDocument.ParseAsync(documentStream);
+        var paths = document.RootElement.GetProperty("paths");
+
+        AssertOperation(paths, "/support/sessions/active", "A customer's own open session (204 when none) or an agent's active sessions.");
+        AssertOperation(paths, "/support/sessions/{sessionId}/messages", "Transcript for a session, ascending by send time, paginated. Participant or administrator only.");
+        AssertOperation(paths, "/support/sessions", "All sessions, paginated and filterable by status. Back-office staff only.");
+    }
+
+    private static void AssertOperation(JsonElement paths, string path, string expectedSummary)
+    {
+        var operation = paths.GetProperty(path).GetProperty("get");
+
+        operation.GetProperty("summary").GetString().Should().Be(expectedSummary);
+        operation.GetProperty("tags").EnumerateArray().Select(tag => tag.GetString()).Should().Contain("CustomerSupport");
+
+        var responseSchema = operation
+            .GetProperty("responses")
+            .GetProperty("200")
+            .GetProperty("content")
+            .GetProperty("application/json")
+            .GetProperty("schema");
+
+        responseSchema.ValueKind.Should().NotBe(JsonValueKind.Undefined);
+        responseSchema.ValueKind.Should().NotBe(JsonValueKind.Null);
     }
 
     private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string uri, Guid userId, string role)

--- a/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
+++ b/src/Services/CustomerSupport/FreshCart.CustomerSupport.Tests/Endpoints/SupportEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using FluentAssertions;
 using FreshCart.CustomerSupport.Api.Domain;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
 namespace FreshCart.CustomerSupport.Tests.Endpoints;
@@ -135,13 +136,86 @@ public sealed class SupportEndpointsTests(SupportApiFactory factory) : IClassFix
         await using var documentStream = await response.Content.ReadAsStreamAsync();
         using var document = await JsonDocument.ParseAsync(documentStream);
         var paths = document.RootElement.GetProperty("paths");
+        var schemas = document.RootElement.GetProperty("components").GetProperty("schemas");
 
-        AssertOperation(paths, "/support/sessions/active", "A customer's own open session (204 when none) or an agent's active sessions.");
-        AssertOperation(paths, "/support/sessions/{sessionId}/messages", "Transcript for a session, ascending by send time, paginated. Participant or administrator only.");
-        AssertOperation(paths, "/support/sessions", "All sessions, paginated and filterable by status. Back-office staff only.");
+        AssertOperation(
+            paths,
+            schemas,
+            "/support/sessions/active",
+            "A customer's own open session (204 when none) or an agent's active sessions.",
+            ["sessionId", "topic", "customerId", "customerDisplayName", "agentId", "agentDisplayName", "status", "startedOnUtc"]);
+        AssertOperation(
+            paths,
+            schemas,
+            "/support/sessions/{sessionId}/messages",
+            "Transcript for a session, ascending by send time, paginated. Participant or administrator only.",
+            ["messageId", "sessionId", "senderId", "senderDisplayName", "senderRole", "text", "sentOnUtc"]);
+        AssertOperation(
+            paths,
+            schemas,
+            "/support/sessions",
+            "All sessions, paginated and filterable by status. Back-office staff only.",
+            ["sessionId", "topic", "customerId", "customerDisplayName", "agentId", "agentDisplayName", "status", "startedOnUtc"]);
     }
 
-    private static void AssertOperation(JsonElement paths, string path, string expectedSummary)
+    [Fact]
+    public async Task DevelopmentSwaggerUiUsesSelfHostedAssetsAndKeepsOpenApiProtectedByStrictCsp()
+    {
+        using var client = factory.CreateClient();
+
+        using var index = await client.GetAsync("/swagger/index.html");
+        index.StatusCode.Should().Be(HttpStatusCode.OK);
+        var indexHtml = await index.Content.ReadAsStringAsync();
+        indexHtml.Should().Contain("./swagger-ui.css");
+        indexHtml.Should().Contain("./swagger-ui-bundle.js");
+        indexHtml.Should().Contain("./swagger-ui-standalone-preset.js");
+        indexHtml.Should().Contain("./index.js");
+        indexHtml.Should().NotContain("unsafe-inline");
+        indexHtml.Should().NotContain("https://cdn.");
+        GetHeader(index, "Content-Security-Policy").Should().Be(SwaggerCsp);
+
+        foreach (var asset in new[]
+        {
+            "/swagger/swagger-ui.css",
+            "/swagger/swagger-ui-bundle.js",
+            "/swagger/swagger-ui-standalone-preset.js",
+            "/swagger/index.js",
+        })
+        {
+            using var assetResponse = await client.GetAsync(asset);
+            assetResponse.StatusCode.Should().Be(HttpStatusCode.OK, asset);
+        }
+
+        using var documentResponse = await client.GetAsync("/openapi/v1.json");
+        documentResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        AssertStrictSecurityHeaders(documentResponse);
+    }
+
+    [Fact]
+    public async Task ProductionDoesNotExposeSwaggerUiOrOpenApiDocument()
+    {
+        using var productionFactory = new SupportApiFactory { EnvironmentName = "Production" };
+        using var client = productionFactory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            AllowAutoRedirect = false,
+        });
+
+        using var swagger = await client.GetAsync("/swagger/index.html");
+        swagger.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        AssertStrictSecurityHeaders(swagger);
+
+        using var document = await client.GetAsync("/openapi/v1.json");
+        document.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        AssertStrictSecurityHeaders(document);
+    }
+
+    private static void AssertOperation(
+        JsonElement paths,
+        JsonElement schemas,
+        string path,
+        string expectedSummary,
+        IReadOnlyList<string> expectedItemProperties)
     {
         var operation = paths.GetProperty(path).GetProperty("get");
 
@@ -155,9 +229,73 @@ public sealed class SupportEndpointsTests(SupportApiFactory factory) : IClassFix
             .GetProperty("application/json")
             .GetProperty("schema");
 
-        responseSchema.ValueKind.Should().NotBe(JsonValueKind.Undefined);
-        responseSchema.ValueKind.Should().NotBe(JsonValueKind.Null);
+        var resolvedResponseSchema = ResolveSchema(responseSchema, schemas);
+        resolvedResponseSchema.ValueKind.Should().Be(JsonValueKind.Object);
+
+        if (resolvedResponseSchema.TryGetProperty("type", out var type) && string.Equals(type.GetString(), "array", StringComparison.Ordinal))
+        {
+            AssertProperties(ResolveSchema(resolvedResponseSchema.GetProperty("items"), schemas), expectedItemProperties);
+            return;
+        }
+
+        AssertProperties(resolvedResponseSchema, ["pageNumber", "pageSize", "totalItemCount", "items"]);
+        var items = ResolveSchema(resolvedResponseSchema.GetProperty("properties").GetProperty("items"), schemas);
+        items.GetProperty("type").GetString().Should().Be("array");
+        AssertProperties(ResolveSchema(items.GetProperty("items"), schemas), expectedItemProperties);
     }
+
+    private static JsonElement ResolveSchema(JsonElement schema, JsonElement schemas)
+    {
+        while (schema.TryGetProperty("$ref", out var reference))
+        {
+            var referenceParts = reference.GetString()!.Split('/');
+            var schemaName = referenceParts[^1];
+            schema = schemas.GetProperty(schemaName);
+        }
+
+        return schema;
+    }
+
+    private static void AssertProperties(JsonElement schema, IReadOnlyList<string> expectedProperties)
+    {
+        var properties = schema.GetProperty("properties");
+        foreach (var expectedProperty in expectedProperties)
+        {
+            properties.TryGetProperty(expectedProperty, out _).Should().BeTrue($"schema should describe {expectedProperty}");
+        }
+    }
+
+    private static string GetHeader(HttpResponseMessage response, string name)
+    {
+        if (response.Headers.TryGetValues(name, out var values))
+        {
+            return values.Single();
+        }
+
+        if (response.Content.Headers.TryGetValues(name, out values))
+        {
+            return values.Single();
+        }
+
+        throw new InvalidOperationException($"Missing {name} response header.");
+    }
+
+    private static void AssertStrictSecurityHeaders(HttpResponseMessage response)
+    {
+        GetHeader(response, "X-Content-Type-Options").Should().Be("nosniff");
+        GetHeader(response, "X-Frame-Options").Should().Be("DENY");
+        GetHeader(response, "Referrer-Policy").Should().Be("strict-origin-when-cross-origin");
+        GetHeader(response, "Permissions-Policy").Should().Be("accelerometer=(), camera=(), geolocation=(), microphone=(), payment=()");
+        GetHeader(response, "Cross-Origin-Opener-Policy").Should().Be("same-origin");
+        GetHeader(response, "Cross-Origin-Embedder-Policy").Should().Be("require-corp");
+        GetHeader(response, "Cross-Origin-Resource-Policy").Should().Be("same-origin");
+        GetHeader(response, "Content-Security-Policy").Should().Be(StrictApiCsp);
+        response.Headers.Contains("Server").Should().BeFalse();
+        response.Headers.Contains("X-Powered-By").Should().BeFalse();
+    }
+
+    private const string StrictApiCsp = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
+    private const string SwaggerCsp = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'";
 
     private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string uri, Guid userId, string role)
     {


### PR DESCRIPTION
Fixes #4.

Customer Support now serves a self-hosted Swagger UI at /swagger in Development, using the existing ASP.NET Core OpenAPI document. Carter/Minimal API summaries and typed response metadata document the three support operations; tests resolve schema references and verify session/message properties and pagination envelopes. Production exposes neither the UI nor the document.

The API's strict CSP and authorization remain intact. Development Swagger routes permit self-hosted assets and one exact SHA-256 hash for the bundled logo's inline SVG style; external validation is disabled. Setup guides use HTTPS and accurately describe the embedded dashboard/support-console routes.

Validation at 2ff5e13c21a63b2e52ebede68f58a2343d9cd748: all9 hosted checks pass;59 CustomerSupport tests pass with zero skipped; Chromium, Firefox and WebKit each execute both customer journeys against the merged HTTPS frontend40ed245. CI captures actual documentation responses and headers. Browser-harness rendering shows all3 operations/all14 expected model properties, no CSP/runtime errors, and only same-origin200 resources. All8 final captured body hashes and CSP headers match the browser-verified fixture. Windows Application Control blocks local assembly execution; Linux CI provides the full-suite proof.
